### PR TITLE
`Instance` and `UserStub` changes

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+User.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+User.swift
@@ -41,14 +41,15 @@ public extension ApiClient {
     
     /// Loads the currently authenticated user
     func loadUser() async throws -> UserStub {
-        // TODO: should this cache? Implicitly via ApiClient?
+        if let myUser { return myUser.stub }
+        
         let request = GetSiteRequest()
         let response = try await perform(request)
 
         guard let user = response.myUser else {
             throw UserError.noUserInResponse
         }
-        guard let token else {
+        guard token != nil else {
             throw UserError.unauthenticated
         }
         
@@ -59,7 +60,6 @@ public extension ApiClient {
             id: user.localUserView.localUser.id,
             name: name,
             actorId: parseActorId(instanceLink: response.actorId, name: name),
-            accessToken: token,
             nickname: user.localUserView.person.displayName,
             cachedSiteVersion: .init(response.version),
             avatarUrl: user.localUserView.person.avatar,

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -71,7 +71,7 @@ public class ApiClient {
         }
         Self.apiClientCache.changeToken(for: baseUrl, oldToken: token, newToken: newToken)
         self.token = newToken
-        self.myUser?.stub.deleteTokenFromKeychain()
+        self.myUser?.stub.saveTokenToKeychain()
     }
     
     /// Creates or retrieves an API client for the given connection parameters

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -225,7 +225,7 @@ extension ApiClient {
         // Should ONLY be used when we get a new token for THE SAME account
         func changeToken(for baseUrl: URL, oldToken: String?, newToken: String?) {
             let oldCacheId = getCacheId(for: baseUrl, with: oldToken)
-            let newCacheId = getCacheId(for: baseUrl, with: oldToken)
+            let newCacheId = getCacheId(for: baseUrl, with: newToken)
             cachedItems[newCacheId] = cachedItems[oldCacheId]
             cachedItems[oldCacheId] = nil
         }

--- a/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
@@ -15,7 +15,7 @@ class Instance1Cache: ApiTypeBackedCache<Instance1, ApiSite> {
             created: apiType.published,
             updated: apiType.updated,
             publicKey: apiType.publicKey,
-            name: apiType.name,
+            name: apiType.actorId.host() ?? "unknown",
             displayName: apiType.name,
             description: apiType.sidebar,
             avatar: apiType.icon,

--- a/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
@@ -11,11 +11,11 @@ class Instance1Cache: ApiTypeBackedCache<Instance1, ApiSite> {
     override func performModelTranslation(api: ApiClient, from apiType: ApiSite) -> Instance1 {
         .init(
             api: api,
+            actorId: apiType.actorId,
             id: apiType.id,
             created: apiType.published,
             updated: apiType.updated,
             publicKey: apiType.publicKey,
-            name: apiType.actorId.host() ?? "unknown",
             displayName: apiType.name,
             description: apiType.sidebar,
             avatar: apiType.icon,

--- a/Sources/MlemMiddleware/Content Models/Instance/Instance1.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/Instance1.swift
@@ -13,8 +13,8 @@ public final class Instance1: Instance1Providing {
     public var api: ApiClient
     public var instance1: Instance1 { self }
     
+    public let actorId: URL
     public let id: Int
-    public let name: String
     public let created: Date
     public let updated: Date?
     public let publicKey: String
@@ -27,11 +27,11 @@ public final class Instance1: Instance1Providing {
     
     internal init(
         api: ApiClient,
+        actorId: URL,
         id: Int,
         created: Date,
         updated: Date?,
         publicKey: String,
-        name: String,
         displayName: String = "",
         description: String? = nil,
         avatar: URL? = nil,
@@ -39,11 +39,11 @@ public final class Instance1: Instance1Providing {
         lastRefreshDate: Date = .distantPast
     ) {
         self.api = api
+        self.actorId = actorId
         self.id = id
         self.created = created
         self.updated = updated
         self.publicKey = publicKey
-        self.name = name
         self.displayName = displayName
         self.description = description
         self.avatar = avatar

--- a/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public protocol Instance1Providing: ProfileProviding, Identifiable {
+    var api: ApiClient { get }
     var instance1: Instance1 { get }
     
     var id: Int { get }
@@ -38,4 +39,8 @@ public extension Instance1Providing {
     var updated_: Date? { instance1.updated }
     var publicKey_: String? { instance1.publicKey }
     var lastRefreshDate_: Date? { instance1.lastRefreshDate }
+}
+
+public extension Instance1Providing {
+    var host: String { name } // For consistency with ContentStub
 }

--- a/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
@@ -7,8 +7,7 @@
 
 import Foundation
 
-public protocol Instance1Providing: ProfileProviding, Identifiable {
-    var api: ApiClient { get }
+public protocol Instance1Providing: ProfileProviding, ContentStub, Identifiable {
     var instance1: Instance1 { get }
     
     var id: Int { get }
@@ -19,8 +18,8 @@ public protocol Instance1Providing: ProfileProviding, Identifiable {
 public typealias Instance = Instance1Providing
 
 public extension Instance1Providing {
+    var actorId: URL { instance1.actorId }
     var id: Int { instance1.id }
-    var name: String { instance1.name }
     var displayName: String { instance1.displayName }
     var description: String? { instance1.description }
     var avatar: URL? { instance1.avatar }
@@ -31,7 +30,6 @@ public extension Instance1Providing {
     var lastRefreshDate: Date { instance1.lastRefreshDate }
     
     var id_: Int? { instance1.id }
-    var name_: String? { instance1.name }
     var displayName_: String? { instance1.displayName }
     var description_: String? { instance1.description }
     var avatar_: URL? { instance1.avatar }
@@ -42,5 +40,5 @@ public extension Instance1Providing {
 }
 
 public extension Instance1Providing {
-    var host: String { name } // For consistency with ContentStub
+    var name: String { host ?? "unknown" }
 }

--- a/Sources/MlemMiddleware/Content Models/User/UserStub.swift
+++ b/Sources/MlemMiddleware/Content Models/User/UserStub.swift
@@ -90,7 +90,7 @@ public final class UserStub: UserProviding, Codable {
     }
     
     public func encode(to encoder: Encoder) throws {
-        keychain[getKeychainId(actorId: actorId)] = api.token
+        saveTokenToKeychain()
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(name, forKey: .username)
@@ -107,6 +107,10 @@ public final class UserStub: UserProviding, Codable {
     
     public func updateToken(_ newToken: String) {
         self.api.updateToken(newToken)
+    }
+    
+    func saveTokenToKeychain() {
+        keychain[getKeychainId(actorId: actorId)] = api.token
     }
     
     public func deleteTokenFromKeychain() {


### PR DESCRIPTION
This PR contains changes to support the login system I'm working on.

- The keychain identifier used for storing account tokens now uses `actorId` (which is always unique) rather than `id` (which isn't guaranteed to be unique). It's backwards-compatible with the `id` system.
- Added an `updateToken` method to `ApiClient`. This will only be used when refreshing the token for the same account, and should never be used to change the account an `ApiClient` is logged into.
- Added a `deleteTokenFromKeychain` method to `UserStub`, which I'll be calling when a user signs out.
- Conformed `Instance` models to `ActorIdentifiable`.