### PR TITLE
Fix `localhost`

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+Site.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Site.swift
@@ -11,7 +11,8 @@ public extension ApiClient {
     func getSite() async throws -> Instance3 {
         let request = GetSiteRequest()
         let response = try await perform(request)
-        let model = caches.instance3.getModel(api: self, from: response)
+        var model = caches.instance3.getModel(api: self, from: response)
+        model.local = true
         myInstance = model
         return model
     }

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -63,6 +63,16 @@ public class ApiClient {
         ApiClient.apiClientCache.clean()
     }
     
+    /// Return a new `ApiClient` withou a token.
+    public func loggedOut() -> ApiClient {
+        .getApiClient(for: self.baseUrl, with: nil)
+    }
+    
+    /// Return a new `ApiClient` with the given token.
+    public func loggedIn(token: String) -> ApiClient {
+        .getApiClient(for: self.baseUrl, with: token)
+    }
+    
     /// This should **only** be used when we get a new token for **the same** account!
     public func updateToken(_ newToken: String) {
         guard token != nil else {
@@ -100,7 +110,6 @@ public class ApiClient {
     @discardableResult
     func perform<Request: ApiRequest>(_ request: Request) async throws -> Request.Response {
         let urlRequest = try urlRequest(from: request)
-
         let (data, response) = try await execute(urlRequest)
         
         if let response = response as? HTTPURLResponse {

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -63,7 +63,7 @@ public class ApiClient {
         ApiClient.apiClientCache.clean()
     }
     
-    /// Return a new `ApiClient` withou a token.
+    /// Return a new `ApiClient` without a token.
     public func loggedOut() -> ApiClient {
         .getApiClient(for: self.baseUrl, with: nil)
     }

--- a/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/InstanceCaches.swift
@@ -9,9 +9,9 @@ import Foundation
 
 class Instance1Cache: ApiTypeBackedCache<Instance1, ApiSite> {
     override func performModelTranslation(api: ApiClient, from apiType: ApiSite) -> Instance1 {
-        .init(
+        return .init(
             api: api,
-            actorId: apiType.actorId,
+            actorId: api.baseUrl,
             id: apiType.id,
             created: apiType.published,
             updated: apiType.updated,

--- a/Sources/MlemMiddleware/Content Models/Instance/Instance1.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/Instance1.swift
@@ -25,6 +25,8 @@ public final class Instance1: Instance1Providing {
     public var banner: URL?
     public var lastRefreshDate: Date = .distantPast
     
+    public var local: Bool = false
+    
     internal init(
         api: ApiClient,
         actorId: URL,

--- a/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
@@ -13,6 +13,7 @@ public protocol Instance1Providing: ProfileProviding, ContentStub, Identifiable 
     var id: Int { get }
     var publicKey: String { get }
     var lastRefreshDate: Date { get }
+    var local: Bool { get }
 }
 
 public typealias Instance = Instance1Providing
@@ -28,6 +29,9 @@ public extension Instance1Providing {
     var updated: Date? { instance1.updated }
     var publicKey: String { instance1.publicKey }
     var lastRefreshDate: Date { instance1.lastRefreshDate }
+    internal(set) var local: Bool { get { instance1.local } set {
+        instance1.local = newValue
+    }}
     
     var id_: Int? { instance1.id }
     var displayName_: String? { instance1.displayName }
@@ -37,8 +41,13 @@ public extension Instance1Providing {
     var updated_: Date? { instance1.updated }
     var publicKey_: String? { instance1.publicKey }
     var lastRefreshDate_: Date? { instance1.lastRefreshDate }
+    var local_: Bool { instance1.local }
 }
 
 public extension Instance1Providing {
     var name: String { host ?? "unknown" }
+    
+    var guestApi: ApiClient {
+        .getApiClient(for: local ? api.baseUrl : actorId, with: nil)
+    }
 }

--- a/Sources/MlemMiddleware/Content Models/ProfileProviding.swift
+++ b/Sources/MlemMiddleware/Content Models/ProfileProviding.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol ProfileProviding {
+public protocol ProfileProviding: ActorIdentifiable {
     var name: String { get }
     var displayName: String { get }
     var description: String? { get }


### PR DESCRIPTION
When `ApiClient` fetches its own `Instance`, it sets a property `local` of that instance to `true`. The `guestApi` computed property of `Instance` can then be used to get the correct `ApiClient`. I've also added a couple of convenience methods to `ApiClient`, and conformed `ProfileProviding` to `ActorIdentifiable` (which is unrelated, but I'm throwing it in as I've got a hunch I'll need it later). 

The Login PR on `Mlem` is up-to-date with these changes