### PR TITLE
Make `CoreCache` public

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+Caches.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Caches.swift
@@ -7,8 +7,12 @@
 
 import Foundation
 
-struct WeakReference<Content: AnyObject> {
-    weak var content: Content?
+public struct WeakReference<Content: AnyObject> {
+    public weak var content: Content?
+    
+    public init(content: Content) {
+        self.content = content
+    }
 }
 
 public protocol CacheIdentifiable {

--- a/Sources/MlemMiddleware/API Client/Caching/CoreCache.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/CoreCache.swift
@@ -8,18 +8,22 @@
 import Foundation
 
 /// Class providing common caching behavior
-class CoreCache<Content: CacheIdentifiable & AnyObject> {
-    var cachedItems: [Int: WeakReference<Content>] = .init()
+open class CoreCache<Content: CacheIdentifiable & AnyObject> {
+    public var cachedItems: [Int: WeakReference<Content>] = .init()
+    
+    public init() {
+        self.cachedItems = .init()
+    }
     
     /// Retrieves the cached model with the given cacheId, if present
     /// - Parameter cacheId: cacheId of the model to retrieve
     /// - Returns: cached model if present, nil otherwise
-    func retrieveModel(cacheId: Int) -> Content? {
+    public func retrieveModel(cacheId: Int) -> Content? {
         cachedItems[cacheId]?.content
     }
     
     /// Remove dead references
-    func clean() {
+    public func clean() {
         for (key, value) in cachedItems where value.content == nil {
             print("Removed value with id \(key)")
             cachedItems[key] = nil


### PR DESCRIPTION
I'm using this class in `Mlem` to ensure that we don't have duplicate instances of `GuestAccount`.