### PR TITLE
Mark-read Batching

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -77,6 +77,7 @@ extension ApiClient: PostFeedProvider {
         semaphore: UInt? = nil
     ) async throws {
         // We *must* use `postId` in 0.18 versions, and we *must* use `postIds` from 0.19.4 onwards.
+        // On versions 0.19.0 to 0.19.3, either parameter is allowed.
         let version = try await version
         let request: MarkPostAsReadRequest
         if version >= .v19_0 {
@@ -130,7 +131,9 @@ extension ApiClient: PostFeedProvider {
             if !response.success {
                 throw ApiClientError.unsuccessful
             }
-            markReadQueue.subtract(ids)
+            if read {
+                markReadQueue.subtract(ids)
+            }
         } catch {
             self.markReadQueue.formUnion(markReadQueueCopy)
             throw error

--- a/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -115,9 +115,9 @@ extension ApiClient: PostFeedProvider {
         let idsToSend: Set<Int>
         let markReadQueueCopy: Set<Int>
         if read, includeQueuedPosts {
-            idsToSend = ids.union(self.markReadQueue)
             markReadQueueCopy = self.markReadQueue
             self.markReadQueue.removeAll()
+            idsToSend = ids.union(markReadQueueCopy)
         } else {
             markReadQueueCopy = []
             idsToSend = ids

--- a/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -68,15 +68,94 @@ extension ApiClient: PostFeedProvider {
         return nil
     }
     
+    /// Mark the given post as read. Works on all versions.
+    /// On v0.19.0 and above, calling this will also mark any queued posts as read unless `includeQueuedPosts` is set to `false`.
+    public func markPostAsRead(
+        id: Int,
+        read: Bool = true,
+        includeQueuedPosts: Bool = true,
+        semaphore: UInt? = nil
+    ) async throws {
+        // We *must* use `postId` in 0.18 versions, and we *must* use `postIds` from 0.19.4 onwards.
+        let version = try await version
+        let request: MarkPostAsReadRequest
+        if version >= .v19_0 {
+            try await self.markPostsAsRead(
+                ids: [id],
+                read: read,
+                includeQueuedPosts: includeQueuedPosts,
+                semaphore: semaphore
+            )
+        } else {
+            request = MarkPostAsReadRequest(postId: id, read: read, postIds: nil)
+            let response = try await perform(request)
+            if !response.success {
+                throw ApiClientError.unsuccessful
+            }
+            markReadQueue.remove(id)
+            if let post = caches.post2.retrieveModel(cacheId: id) {
+                post.readManager.updateWithReceivedValue(read, semaphore: semaphore)
+                post.readQueued = false
+            }
+        }
+    }
+    
+    /// Mark the given posts as read. Only works on v0.19.0 and above; on lower versions, use `markPostAsRead` instead.
+    /// Calling this will also mark any queued posts as read unless `includeQueuedPosts` is set to `false`.
+    public func markPostsAsRead(
+        ids: Set<Int>,
+        read: Bool = true,
+        includeQueuedPosts: Bool = true,
+        semaphore: UInt? = nil
+    ) async throws {
+        let version = try await version
+        guard version >= .v19_0 else { throw ApiClientError.unsupportedLemmyVersion }
+        
+        let idsToSend: Set<Int>
+        let markReadQueueCopy: Set<Int>
+        if read, includeQueuedPosts {
+            idsToSend = ids.union(self.markReadQueue)
+            markReadQueueCopy = self.markReadQueue
+            self.markReadQueue.removeAll()
+        } else {
+            markReadQueueCopy = []
+            idsToSend = ids
+        }
+        
+        guard !idsToSend.isEmpty else { return }
+        
+        do {
+            let request = MarkPostAsReadRequest(postId: nil, read: read, postIds: Array(idsToSend))
+            let response = try await perform(request)
+            if !response.success {
+                throw ApiClientError.unsuccessful
+            }
+            markReadQueue.subtract(ids)
+        } catch {
+            self.markReadQueue.formUnion(markReadQueueCopy)
+            throw error
+        }
+        for post in idsToSend.compactMap({ caches.post2.retrieveModel(cacheId: $0) }) {
+            post.readManager.updateWithReceivedValue(read, semaphore: semaphore)
+            post.readQueued = false
+        }
+    }
+    
+    public func flushPostReadQueue() async throws {
+        if !markReadQueue.isEmpty {
+            try await markPostsAsRead(ids: [], read: true)
+        }
+    }
+    
     @discardableResult
-    public func voteOnPost(id: Int, score: ScoringOperation, semaphore: UInt?) async throws -> Post2 {
+    public func voteOnPost(id: Int, score: ScoringOperation, semaphore: UInt? = nil) async throws -> Post2 {
         let request = LikePostRequest(postId: id, score: score.rawValue)
         let response = try await perform(request)
         return caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)
     }
     
     @discardableResult
-    public func savePost(id: Int, save: Bool, semaphore: UInt?) async throws -> Post2 {
+    public func savePost(id: Int, save: Bool, semaphore: UInt? = nil) async throws -> Post2 {
         let request = SavePostRequest(postId: id, save: save)
         let response = try await perform(request)
         return caches.post2.getModel(api: self, from: response.postView, semaphore: semaphore)

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -32,17 +32,20 @@ public class ApiClient {
     internal weak var myPerson: Person4?
     internal weak var subscriptions: SubscriptionList?
     
+    /// Stores the IDs of posts that are queued to be marked read.
+    internal var markReadQueue: Set<Int> = .init()
+    
     /// Returns the `fetchedVersion` if the version has already been fetched. Otherwise, waits until the version has been fetched before returning the received value.
-    public var version: SiteVersion? {
-        get async {
+    public var version: SiteVersion {
+        get async throws {
             if let fetchedVersion {
                 return fetchedVersion
             } else {
                 if let fetchSiteTask {
                     let result = await fetchSiteTask.result
-                    return try? result.get()
+                    return try result.get()
                 } else {
-                    return try? await fetchSiteVersion()
+                    return try await fetchSiteVersion()
                 }
             }
         }

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -33,7 +33,7 @@ public class ApiClient {
     internal weak var subscriptions: SubscriptionList?
     
     /// Stores the IDs of posts that are queued to be marked read.
-    internal var markReadQueue: Set<Int> = .init()
+    internal var markReadQueue: MarkReadQueue = .init()
     
     /// Returns the `fetchedVersion` if the version has already been fetched. Otherwise, waits until the version has been fetched before returning the received value.
     public var version: SiteVersion {

--- a/Sources/MlemMiddleware/API Client/ApiClientError.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClientError.swift
@@ -20,6 +20,9 @@ public enum ApiClientError: Error {
     case invalidSession
     case decoding(Data, Error?)
     case insufficientPermissions
+    /// Thrown when a `false` value of `SuccessResponse` is returned
+    case unsuccessful
+    case unsupportedLemmyVersion
 }
 
 extension ApiClientError: CustomStringConvertible {
@@ -50,6 +53,10 @@ extension ApiClientError: CustomStringConvertible {
             }
             
             return "Unable to decode: \(string)"
+        case .unsuccessful:
+            return "Operation was unsuccessful."
+        case .unsupportedLemmyVersion:
+            return "This version of Lemmy doesn't support that operation."
         }
     }
 }

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Community+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Community+CacheExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Community1: CacheIdentifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
     
     func update(with community: ApiCommunity) {
         updated = community.updated
@@ -25,7 +25,7 @@ extension Community1: CacheIdentifiable {
 }
 
 extension Community2: CacheIdentifiable {
-    public var cacheId: Int { community1.cacheId }
+    public var cacheId: Int { id }
     
     func update(with communityView: ApiCommunityView, semaphore: UInt? = nil) {
         subscribedManager.updateWithReceivedValue(communityView.subscribed.isSubscribed, semaphore: semaphore)
@@ -43,7 +43,7 @@ extension Community2: CacheIdentifiable {
 }
 
 extension Community3: CacheIdentifiable {
-    public var cacheId: Int { community2.cacheId }
+    public var cacheId: Int { id }
     
     func update(with response: ApiGetCommunityResponse, semaphore: UInt? = nil) {
         moderators = response.moderators.map { moderatorView in

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Instance+CacheExtensions.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Instance1: CacheIdentifiable {
     // Instance and ApiClient share equatability properties--two instances are different iff they are different servers and being connected to using a different user. This makes intuitive sense given that instance is the source of things like post feeds, which can vary depending on the calling user (even instance-generics like All and Local will produce varying responses for different calling users, e.g., return an upvoted or neutral post)
-    public var cacheId: Int { api.cacheId }
+    public var cacheId: Int { id }
     
     func update(with site: ApiSite) {
         displayName = site.name
@@ -21,7 +21,7 @@ extension Instance1: CacheIdentifiable {
 }
 
 extension Instance2: CacheIdentifiable {
-    public var cacheId: Int { instance1.cacheId }
+    public var cacheId: Int { id }
     
     func update(with siteView: ApiSiteView) {
         instance1.update(with: siteView.site)
@@ -29,7 +29,7 @@ extension Instance2: CacheIdentifiable {
 }
 
 extension Instance3: CacheIdentifiable {
-    public var cacheId: Int { instance2.cacheId }
+    public var cacheId: Int { id }
     
     func update(with response: ApiGetSiteResponse) {
         version = SiteVersion(response.version)

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Person+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Person+CacheExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Person1: CacheIdentifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
     
     func update(with person: ApiPerson) {
         updated = person.updated
@@ -33,7 +33,7 @@ extension Person1: CacheIdentifiable {
 }
 
 extension Person2: CacheIdentifiable {
-    public var cacheId: Int { person1.cacheId }
+    public var cacheId: Int { id }
     
     func update(with apiType: any Person2ApiBacker) {
         postCount = apiType.counts.postCount
@@ -43,7 +43,7 @@ extension Person2: CacheIdentifiable {
 }
 
 extension Person3: CacheIdentifiable {
-    public var cacheId: Int { person2.cacheId }
+    public var cacheId: Int { id }
     
     func update(moderatedCommunities: [Community1], person2ApiBacker: any Person2ApiBacker) {
         self.moderatedCommunities = moderatedCommunities
@@ -52,7 +52,7 @@ extension Person3: CacheIdentifiable {
 }
 
 extension Person4: CacheIdentifiable {
-    public var cacheId: Int { person3.cacheId }
+    public var cacheId: Int { id }
     
     func update(with apiMyUserInfo: ApiMyUserInfo) {
         let moderates = apiMyUserInfo.moderates.map { moderatorView in

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Post+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Post+CacheExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Post1: CacheIdentifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
     
     func update(with post: ApiPost) {
         updated = post.updated
@@ -35,7 +35,7 @@ extension Post1: CacheIdentifiable {
 }
 
 extension Post2: CacheIdentifiable {
-    public var cacheId: Int { post1.cacheId }
+    public var cacheId: Int { id }
     
     func update(with post: ApiPostView, semaphore: UInt? = nil) {
         commentCount = post.counts.comments
@@ -46,7 +46,7 @@ extension Post2: CacheIdentifiable {
         unreadCommentCount = post.unreadComments
         savedManager.updateWithReceivedValue(post.saved, semaphore: semaphore)
         readManager.updateWithReceivedValue(post.read, semaphore: semaphore)
-        
+
         post1.update(with: post.post)
         creator.update(with: post.creator)
         community.update(with: post.community)

--- a/Sources/MlemMiddleware/API Client/Helpers/MarkReadQueue.swift
+++ b/Sources/MlemMiddleware/API Client/Helpers/MarkReadQueue.swift
@@ -1,0 +1,33 @@
+//
+//  MarkReadQueue.swift
+//
+//
+//  Created by Sjmarf on 29/05/2024.
+//
+
+import Foundation
+
+actor MarkReadQueue {
+    var ids: Set<Int> = .init()
+    
+    func popAll() -> Set<Int> {
+        defer { ids.removeAll() }
+        return ids
+    }
+    
+    func add(_ postId: Int) {
+        ids.insert(postId)
+    }
+    
+    func remove(_ postId: Int) {
+        ids.remove(postId)
+    }
+    
+    func union(_ other: Set<Int>) {
+        ids.formUnion(other)
+    }
+    
+    func subtract(_ other: Set<Int>) {
+        ids.subtract(other)
+    }
+}

--- a/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
@@ -14,11 +14,12 @@ public protocol Interactable2Providing: Interactable1Providing {
     var votes: VotesModel { get }
     var saved: Bool { get }
     
-    func vote(_ newVote: ScoringOperation)
-    func toggleSave()
+    func updateVote(_ newVote: ScoringOperation)
+    func updateSave(_ newValue: Bool)
 }
 
 public extension Interactable2Providing {
-    func toggleUpvote() { vote(votes.myVote == .upvote ? .none : .upvote) }
-    func toggleDownvote() { vote(votes.myVote == .downvote ? .none : .downvote) }
+    func toggleUpvote() { updateVote(votes.myVote == .upvote ? .none : .upvote) }
+    func toggleDownvote() { updateVote(votes.myVote == .downvote ? .none : .downvote) }
+    func toggleSave() { updateSave(!saved) }
 }

--- a/Sources/MlemMiddleware/Content Models/Internal/SiteVersion.swift
+++ b/Sources/MlemMiddleware/Content Models/Internal/SiteVersion.swift
@@ -12,7 +12,7 @@ public enum SiteVersion: Equatable, Hashable {
     case zero
     case infinity
     
-    init(_ version: String) {
+    public init(_ version: String) {
         let parts = version.split(separator: "-")
         if let firstPart = parts.first {
             let components = firstPart.split(separator: ".").compactMap { Int($0) }
@@ -27,7 +27,7 @@ public enum SiteVersion: Equatable, Hashable {
     }
     
     // swiftlint: disable large_tuple
-    var parts: (Int, Int, Int)? {
+    public var parts: (Int, Int, Int)? {
         switch self {
         case let .release(major, minor, patch):
             return (major, minor, patch)
@@ -36,6 +36,18 @@ public enum SiteVersion: Equatable, Hashable {
         }
     }
     // swiftlint: enable large_tuple
+    
+    public static let v18_0: Self = .init("0.18.0")
+    public static let v18_1: Self = .init("0.18.1")
+    public static let v18_2: Self = .init("0.18.2")
+    public static let v18_3: Self = .init("0.18.3")
+    public static let v18_4: Self = .init("0.18.4")
+    public static let v18_5: Self = .init("0.18.5")
+    public static let v19_0: Self = .init("0.19.0")
+    public static let v19_1: Self = .init("0.19.1")
+    public static let v19_2: Self = .init("0.19.2")
+    public static let v19_3: Self = .init("0.19.3")
+    public static let v19_4: Self = .init("0.19.4")
 }
 
 extension SiteVersion: CustomStringConvertible {

--- a/Sources/MlemMiddleware/Content Models/Post/Post2.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post2.swift
@@ -24,7 +24,8 @@ public final class Post2: Post2Providing {
     public var votes: VotesModel { votesManager.wrappedValue }
     
     internal var readManager: StateManager<Bool>
-    public var read: Bool { readManager.wrappedValue }
+    public var read: Bool { readManager.wrappedValue || readQueued }
+    internal var readQueued: Bool = false
     
     internal var savedManager: StateManager<Bool>
     public var saved: Bool { savedManager.wrappedValue }

--- a/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
@@ -44,12 +44,14 @@ public extension Post2Providing {
     
     func updateRead(_ newValue: Bool, shouldQueue: Bool = false) {
         if shouldQueue {
-            if newValue {
-                api.markReadQueue.insert(self.id)
-                post2.readQueued = true
-            } else {
-                api.markReadQueue.remove(self.id)
-                post2.readQueued = false
+            Task {
+                if newValue {
+                    await api.markReadQueue.add(self.id)
+                    post2.readQueued = true
+                } else {
+                    await api.markReadQueue.remove(self.id)
+                    post2.readQueued = false
+                }
             }
         } else {
             readManager.performRequest(expectedResult: newValue) { semaphore in
@@ -81,7 +83,9 @@ public extension Post2Providing {
         }
     }
     
-    var queuedForMarkAsRead: Bool { api.markReadQueue.contains(self.id) }
+    var queuedForMarkAsRead: Bool {
+        get async { await api.markReadQueue.ids.contains(self.id) }
+    }
 }
 
 public extension Post2Providing {

--- a/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
@@ -41,19 +41,38 @@ public extension Post2Providing {
     private var votesManager: StateManager<VotesModel> { post2.votesManager }
     private var readManager: StateManager<Bool> { post2.readManager }
     private var savedManager: StateManager<Bool> { post2.savedManager }
-
-    func vote(_ newVote: ScoringOperation) {
-        guard newVote != self.votes.myVote else { return }
-        groupStateRequest(
-            votesManager.ticket(self.votes.applyScoringOperation(operation: newVote)),
-            readManager.ticket(true)
-        ) { semaphore in
-            try await self.api.voteOnPost(id: self.id, score: newVote, semaphore: semaphore)
+    
+    func updateRead(_ newValue: Bool, shouldQueue: Bool = false) {
+        if shouldQueue {
+            if newValue {
+                api.markReadQueue.insert(self.id)
+                post2.readQueued = true
+            } else {
+                api.markReadQueue.remove(self.id)
+                post2.readQueued = false
+            }
+        } else {
+            readManager.performRequest(expectedResult: newValue) { semaphore in
+                try await self.api.markPostAsRead(id: self.id, read: newValue, semaphore: semaphore)
+            }
         }
     }
     
-    func toggleSave() {
-        let newValue = !saved
+    func toggleRead(shouldQueue: Bool = false) {
+        updateRead(!read, shouldQueue: shouldQueue)
+    }
+
+    func updateVote(_ newValue: ScoringOperation) {
+        guard newValue != self.votes.myVote else { return }
+        groupStateRequest(
+            votesManager.ticket(self.votes.applyScoringOperation(operation: newValue)),
+            readManager.ticket(true)
+        ) { semaphore in
+            try await self.api.voteOnPost(id: self.id, score: newValue, semaphore: semaphore)
+        }
+    }
+    
+    func updateSave(_ newValue: Bool) {
         groupStateRequest(
             savedManager.ticket(newValue),
             readManager.ticket(true)
@@ -61,6 +80,8 @@ public extension Post2Providing {
             try await self.api.savePost(id: self.id, save: newValue, semaphore: semaphore)
         }
     }
+    
+    var queuedForMarkAsRead: Bool { api.markReadQueue.contains(self.id) }
 }
 
 public extension Post2Providing {

--- a/Sources/MlemMiddleware/Content Models/StateManager.swift
+++ b/Sources/MlemMiddleware/Content Models/StateManager.swift
@@ -82,8 +82,7 @@ public class StateManager<Value: Equatable> {
         return lastSemaphore
     }
     
-    /// Call at the end of a successful operation. If the caller is the most recent caller, resets clean state and returns true; otherwise updates clean state and returns false.
-    /// If this method returns false, the model SHOULD NOT be reinitialized with the result of a voting operation!
+    /// Call when we receive a value from the ApiClient that we *know* to be up-to-date. Optionally pass a `sempahore` value. If the StateManager is awaiting the result of an operation, the `wrappedValue` will *only* be set if the passed semaphore matches the one that the `StateManager` is waiting for. Otherwise, the value is saved as the `lastVerifiedValue` such that the `StateManager` will rollback to it if the in-progress operation fails.
     @discardableResult
     func updateWithReceivedValue(_ newState: Value, semaphore: UInt?) -> Bool {
         if lastVerifiedValue == nil {

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunity+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunity+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension ApiCommunity: ActorIdentifiable, CacheIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
 }
 
 extension ApiCommunity: Comparable {

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunityView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunityView+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension ApiCommunityView: ActorIdentifiable, CacheIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
 
     public var actorId: URL { community.actorId }
     public var id: Int { community.id }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetCommunityResponse+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetCommunityResponse+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension ApiGetCommunityResponse: CacheIdentifiable, ActorIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
     
     public var actorId: URL { communityView.community.actorId }
     public var id: Int { communityView.community.id }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetSiteResponse+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APIGetSiteResponse+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension ApiGetSiteResponse: ActorIdentifiable, CacheIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
 
     public var actorId: URL { siteView.site.actorId }
     public var id: Int { siteView.site.id }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APIPerson+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APIPerson+Extensions.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 extension ApiPerson: ActorIdentifiable, CacheIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
 }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APIPost+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APIPost+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension ApiPost: ActorIdentifiable, CacheIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
 
     public var actorId: URL { apId }
 }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APIPostView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APIPostView+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension ApiPostView: ActorIdentifiable, CacheIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
 
     public var actorId: URL { post.apId }
     public var id: Int { post.id }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APISite+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APISite+Extensions.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 extension ApiSite: CacheIdentifiable, ActorIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
 }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APISiteView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APISiteView+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension ApiSiteView: CacheIdentifiable, ActorIdentifiable, Identifiable {
-    public var cacheId: Int { actorId.hashValue }
+    public var cacheId: Int { id }
     
     public var actorId: URL { site.actorId }
     public var id: Int { site.id }

--- a/Sources/MlemMiddleware/Custom API Models/Person2ApiBacker.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Person2ApiBacker.swift
@@ -14,7 +14,7 @@ public protocol Person2ApiBacker: ActorIdentifiable, CacheIdentifiable, Identifi
 }
 
 public extension Person2ApiBacker {
-    var cacheId: Int { actorId.hashValue }
+    var cacheId: Int { id }
 
     var id: Int { person.id }
     var actorId: URL { person.actorId }

--- a/Sources/MlemMiddleware/Custom API Models/Person3ApiBacker.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Person3ApiBacker.swift
@@ -15,7 +15,7 @@ public protocol Person3ApiBacker: ActorIdentifiable, CacheIdentifiable, Identifi
 }
 
 public extension Person3ApiBacker {
-    var cacheId: Int { actorId.hashValue }
+    var cacheId: Int { id }
     
     var id: Int { person2ApiBacker.id }
     var actorId: URL { person2ApiBacker.actorId }


### PR DESCRIPTION
Closes #3

Added an `updateRead(_ newValue: Bool, shouldQueue: Bool)` method to `Post2Providing`. If `shouldQueue` is `true`, it will add the post ID to a `Set<Int>` stored in the `ApiClient` rather than sending an immediate request. `ApiClient.flushPostReadQueue` can be called to mark the queued posts as read. If a regular mark-read call is performed, the `ApiClient` will mark the queued posts as read in the same request.

I've switched the `cacheId` values from `actorId.hashvalue` to `id`. This allows the `ApiClient` to easily access a post with a given ID, which it uses to update the read status of posts after a mark-read request finishes.

I've also added some static properties to `SiteVersion`:

```swift
public static let v18_0: Self = .init("0.18.0")
public static let v18_1: Self = .init("0.18.1")
public static let v18_2: Self = .init("0.18.2")
public static let v18_3: Self = .init("0.18.3")
public static let v18_4: Self = .init("0.18.4")
public static let v18_5: Self = .init("0.18.5")
public static let v19_0: Self = .init("0.19.0")
public static let v19_1: Self = .init("0.19.1")
public static let v19_2: Self = .init("0.19.2")
public static let v19_3: Self = .init("0.19.3")
public static let v19_4: Self = .init("0.19.4")
 ```
 
 This allows us to compare versions like this, which I think is cleaner:
 
 ```swift
 if version >= .v19_0 {
 }
 ```
 
Side note: Do we want to name `SiteVersion` something else instead? We standardised our use of "Person" over "User", but we still mix "Instance" and "Site" in public struct/class names. IMO we should either rename `Instance` models to `Site`, or rename `SiteVersion` to `InstanceVersion`.