### PR TITLE
Website Complex

### DIFF
--- a/Sources/MlemMiddleware/Content Models/Post/Post1.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post1.swift
@@ -9,9 +9,9 @@ import Foundation
 import Observation
 
 public struct PostEmbed {
-    let title: String?
-    let description: String?
-    let videoUrl: URL?
+    public let title: String?
+    public let description: String?
+    public let videoUrl: URL?
 }
 
 @Observable

--- a/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
@@ -103,7 +103,9 @@ public extension Post1Providing {
         // post with URL: either image or link
         if let linkUrl {
             // if image, return image link, otherwise return thumbnail
-            return linkUrl.isImage ? .image(linkUrl) : .link(thumbnailUrl)
+            return linkUrl.isImage ? 
+                .image(linkUrl) :
+                .link(.init(content: linkUrl, thumbnail: thumbnailUrl, label: embed?.title ?? title))
         }
 
         // otherwise text, but post.body needs to be present, even if it's an empty string

--- a/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
@@ -128,13 +128,13 @@ public extension Post2Providing {
         case let .image(url):
             // images: only load the image
             ret.append(ImageRequest(url: url, priority: .high))
-        case let .link(url):
+        case let .link(link):
             // websites: load image and favicon
             if let baseURL = linkUrl?.host,
                let favIconURL = URL(string: "https://www.google.com/s2/favicons?sz=64&domain=\(baseURL)") {
                 ret.append(ImageRequest(url: favIconURL))
             }
-            if let url {
+            if let url = link.thumbnail {
                 ret.append(ImageRequest(url: url, priority: .high))
             }
         default:

--- a/Sources/MlemMiddleware/Content Models/PostLink.swift
+++ b/Sources/MlemMiddleware/Content Models/PostLink.swift
@@ -1,0 +1,20 @@
+//
+//  PostLink.swift
+//
+//
+//  Created by Eric Andrews on 2024-07-30.
+//
+
+import Foundation
+
+public struct PostLink: Equatable {
+    public let content: URL
+    public let thumbnail: URL?
+    public let label: String
+    var favicon: URL? {
+        if let baseUrl = content.host {
+            return URL(string: "https://www.google.com/s2/favicons?sz=64&domain=\(baseUrl)")
+        }
+        return nil
+    }
+}

--- a/Sources/MlemMiddleware/Content Models/PostLink.swift
+++ b/Sources/MlemMiddleware/Content Models/PostLink.swift
@@ -11,7 +11,7 @@ public struct PostLink: Equatable {
     public let content: URL
     public let thumbnail: URL?
     public let label: String
-    var favicon: URL? {
+    public var favicon: URL? {
         if let baseUrl = content.host {
             return URL(string: "https://www.google.com/s2/favicons?sz=64&domain=\(baseUrl)")
         }

--- a/Sources/MlemMiddleware/Content Models/PostLink.swift
+++ b/Sources/MlemMiddleware/Content Models/PostLink.swift
@@ -17,7 +17,7 @@ public struct PostLink: Equatable {
         }
         return nil
     }
-    public var host: String? {
+    public var host: String {
         if var host = content.host() {
             host.trimPrefix("www.")
             return host

--- a/Sources/MlemMiddleware/Content Models/PostLink.swift
+++ b/Sources/MlemMiddleware/Content Models/PostLink.swift
@@ -17,4 +17,11 @@ public struct PostLink: Equatable {
         }
         return nil
     }
+    public var host: String? {
+        if var host = content.host() {
+            host.trimPrefix("www.")
+            return host
+        }
+        return "website"
+    }
 }

--- a/Sources/MlemMiddleware/Content Models/PostType.swift
+++ b/Sources/MlemMiddleware/Content Models/PostType.swift
@@ -10,7 +10,7 @@ import Foundation
 public enum PostType: Equatable {
     case text(String)
     case image(URL)
-    case link(URL?)
+    case link(PostLink)
     case titleOnly
     
     public var isText: Bool {

--- a/Sources/MlemMiddleware/Content Models/VotesModel.swift
+++ b/Sources/MlemMiddleware/Content Models/VotesModel.swift
@@ -33,7 +33,7 @@ public struct VotesModel: Hashable, Equatable {
         hasher.combine(myVote)
     }
     
-    static func == (lhs: VotesModel, rhs: VotesModel) {
+    public static func == (lhs: VotesModel, rhs: VotesModel) -> Bool {
         lhs.hashValue == rhs.hashValue
     }
 }


### PR DESCRIPTION
Minor changes to support the website complex:
- `.link` post type now has the new `PostLink` associated value, which bundles the information needed to display a meaningful link preview
- `PostEmbed` members are now public

Unrelated, but it fixes the `Equatable` conformance on `VotesModel`--previously the `==` method did not return any value.