### PR TITLE
Community subscription state-faking

### DIFF
--- a/Sources/MlemMiddleware/API Client/Caching/Caches/CommunityCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/CommunityCaches.swift
@@ -39,8 +39,7 @@ class Community2Cache: ApiTypeBackedCache<Community2, ApiCommunityView> {
         .init(
             api: api,
             community1: api.caches.community1.getModel(api: api, from: apiType.community),
-            subscribed: apiType.subscribed.isSubscribed,
-            subscriberCount: apiType.counts.subscribers,
+            subscription: .init(from: apiType.counts, subscribedType: apiType.subscribed),
             postCount: apiType.counts.posts,
             commentCount: apiType.counts.comments,
             activeUserCount: .init(

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Community+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Community+CacheExtensions.swift
@@ -28,7 +28,6 @@ extension Community2: CacheIdentifiable {
     public var cacheId: Int { id }
     
     func update(with communityView: ApiCommunityView, semaphore: UInt? = nil) {
-        setIfChanged(\.subscriberCount, communityView.counts.subscribers)
         setIfChanged(\.postCount, communityView.counts.posts)
         setIfChanged(\.commentCount, communityView.counts.comments)
         setIfChanged(\.activeUserCount, .init(
@@ -38,7 +37,10 @@ extension Community2: CacheIdentifiable {
             day: communityView.counts.usersActiveDay
         ))
         
-        subscribedManager.updateWithReceivedValue(communityView.subscribed.isSubscribed, semaphore: semaphore)
+        subscriptionManager.updateWithReceivedValue(
+            .init(from: communityView.counts, subscribedType: communityView.subscribed),
+            semaphore: semaphore
+        )
         
         community1.update(with: communityView.community, semaphore: semaphore)
     }

--- a/Sources/MlemMiddleware/Content Models/Comment/Comment1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Comment/Comment1Providing.swift
@@ -13,7 +13,6 @@ public protocol Comment1Providing:
         ContentIdentifiable,
         Interactable1Providing,
         DeletableProviding,
-        ReportableProviding,
         SelectableContentProviding,
         FeedLoadable where FilterType == CommentFilterType {
     var comment1: Comment1 { get }

--- a/Sources/MlemMiddleware/Content Models/Community/Community2.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/Community2.swift
@@ -15,8 +15,8 @@ public final class Community2: Community2Providing {
 
     public let community1: Community1
     
-    internal var subscribedManager: StateManager<Bool>
-    public var subscribed: Bool { subscribedManager.wrappedValue }
+    internal var subscriptionManager: StateManager<SubscriptionModel>
+    internal var subscription: SubscriptionModel { subscriptionManager.wrappedValue }
     
     public var favorited: Bool {
         api.subscriptions?.isFavorited(self) ?? false
@@ -25,7 +25,6 @@ public final class Community2: Community2Providing {
     /// Used to state-fake internally.
     internal var shouldBeFavorited: Bool = false
 
-    public var subscriberCount: Int = 0
     public var postCount: Int = 0
     public var commentCount: Int = 0
     public var activeUserCount: ActiveUserCount = .zero
@@ -33,16 +32,14 @@ public final class Community2: Community2Providing {
     internal init(
         api: ApiClient,
         community1: Community1,
-        subscribed: Bool = false,
-        subscriberCount: Int = 0,
+        subscription: SubscriptionModel,
         postCount: Int = 0,
         commentCount: Int = 0,
         activeUserCount: ActiveUserCount = .zero
     ) {
         self.api = api
         self.community1 = community1
-        self.subscribedManager = .init(wrappedValue: subscribed)
-        self.subscriberCount = subscriberCount
+        self.subscriptionManager = .init(wrappedValue: subscription)
         self.postCount = postCount
         self.commentCount = commentCount
         self.activeUserCount = activeUserCount
@@ -50,10 +47,10 @@ public final class Community2: Community2Providing {
         if favorited, !subscribed {
             self.api.subscriptions?.favoriteIDs.remove(self.id)
         }
-        self.subscribedManager.onSet = { newValue, _ in
+        self.subscriptionManager.onSet = { _, _ in
             self.api.subscriptions?.updateCommunitySubscription(community: self)
         }
         self.shouldBeFavorited = favorited
-        self.subscribedManager.onSet(subscribed, .receive)
+        self.subscriptionManager.onSet(subscription, .receive)
     }
 }

--- a/Sources/MlemMiddleware/Content Models/Community/Community2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/Community2Providing.swift
@@ -31,7 +31,7 @@ public extension Community2Providing {
     var subscribed: Bool { community2.subscription.subscribed }
     var favorited: Bool { community2.favorited }
     var subscriberCount: Int { community2.subscription.total }
-    var localSubscriberCount: Int? { community2.subscription.local }
+    var localSubscriberCount: Int? { community2.subscription.local(communityIsLocal: apiIsLocal) }
     var postCount: Int { community2.postCount }
     var commentCount: Int { community2.commentCount }
     var activeUserCount: ActiveUserCount { community2.activeUserCount }
@@ -39,7 +39,7 @@ public extension Community2Providing {
     var subscribed_: Bool? { community2.subscription.subscribed }
     var favorited_: Bool? { community2.favorited }
     var subscriberCount_: Int? { community2.subscription.total }
-    var localSubscriberCount_: Int? { community2.subscription.local }
+    var localSubscriberCount_: Int? { community2.subscription.local(communityIsLocal: apiIsLocal) }
     var postCount_: Int? { community2.postCount }
     var commentCount_: Int? { community2.commentCount }
     var activeUserCount_: ActiveUserCount? { community2.activeUserCount }

--- a/Sources/MlemMiddleware/Content Models/Community/Community2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/Community2Providing.swift
@@ -31,7 +31,7 @@ public extension Community2Providing {
     var subscribed: Bool { community2.subscription.subscribed }
     var favorited: Bool { community2.favorited }
     var subscriberCount: Int { community2.subscription.total }
-    var localSubscriberCount: Int? { community2.subscription.local(communityIsLocal: apiIsLocal) }
+    var localSubscriberCount: Int? { community2.subscription.local }
     var postCount: Int { community2.postCount }
     var commentCount: Int { community2.commentCount }
     var activeUserCount: ActiveUserCount { community2.activeUserCount }
@@ -39,7 +39,7 @@ public extension Community2Providing {
     var subscribed_: Bool? { community2.subscription.subscribed }
     var favorited_: Bool? { community2.favorited }
     var subscriberCount_: Int? { community2.subscription.total }
-    var localSubscriberCount_: Int? { community2.subscription.local(communityIsLocal: apiIsLocal) }
+    var localSubscriberCount_: Int? { community2.subscription.local }
     var postCount_: Int? { community2.postCount }
     var commentCount_: Int? { community2.commentCount }
     var activeUserCount_: ActiveUserCount? { community2.activeUserCount }

--- a/Sources/MlemMiddleware/Content Models/Community/CommunityStubProviding.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/CommunityStubProviding.swift
@@ -27,6 +27,7 @@ public protocol CommunityStubProviding: CommunityOrPersonStub {
     var subscribed_: Bool? { get }
     var favorited_: Bool? { get }
     var subscriberCount_: Int? { get }
+    var localSubscriberCount_: Int? { get }
     var postCount_: Int? { get }
     var commentCount_: Int? { get }
     var activeUserCount_: ActiveUserCount? { get }
@@ -63,6 +64,7 @@ public extension CommunityStubProviding {
     var subscribed_: Bool? { nil }
     var favorited_: Bool? { nil }
     var subscriberCount_: Int? { nil }
+    var localSubscriberCount_: Int? { nil }
     var postCount_: Int? { nil }
     var commentCount_: Int? { nil }
     var activeUserCount_: ActiveUserCount? { nil }

--- a/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
@@ -19,4 +19,6 @@ public protocol Interactable1Providing: AnyObject, ContentModel, ContentIdentifi
     var commentCount_: Int? { get }
     var votes_: VotesModel? { get }
     var saved_: Bool? { get }
+    
+    func report(reason: String) async throws
 }

--- a/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Represents a post/comment that you *should* be able to interact with, but you cannot actually interact with due to the model being too low-tier.
-public protocol Interactable1Providing: AnyObject, ContentModel, ContentIdentifiable {
+public protocol Interactable1Providing: AnyObject, ContentModel, ReportableProviding, ContentIdentifiable {
     var created: Date { get }
     var updated: Date? { get }
     
@@ -19,6 +19,4 @@ public protocol Interactable1Providing: AnyObject, ContentModel, ContentIdentifi
     var commentCount_: Int? { get }
     var votes_: VotesModel? { get }
     var saved_: Bool? { get }
-    
-    func report(reason: String) async throws
 }

--- a/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
@@ -10,6 +10,7 @@ import Foundation
 // Content that can be upvoted, downvoted, saved etc
 public protocol Interactable2Providing: Interactable1Providing {
     var creator: Person1 { get }
+    var community: Community1 { get }
     var creatorIsModerator: Bool? { get }
     var creatorIsAdmin: Bool? { get }
     var bannedFromCommunity: Bool? { get }

--- a/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
@@ -13,7 +13,6 @@ public protocol Post1Providing:
         Interactable1Providing,
         SelectableContentProviding,
         DeletableProviding,
-        ReportableProviding,
         FeedLoadable where FilterType == PostFilterType {
     var post1: Post1 { get }
     

--- a/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
@@ -98,6 +98,10 @@ public extension Reply1Providing {
             }
         }
     }
+    
+    func report(reason: String) async throws {
+        try await api.reportComment(id: commentId, reason: reason)
+    }
 }
 
 // Override the `ContentIdentifiable` implementation to include `isMention`, because a reply

--- a/Sources/MlemMiddleware/Content Models/StateManager.swift
+++ b/Sources/MlemMiddleware/Content Models/StateManager.swift
@@ -92,6 +92,7 @@ public class StateManager<Value: Equatable> {
         DispatchQueue.main.async {
             if self.wrappedValue != expectedResult {
                 self.wrappedValue = expectedResult
+                print("DEBUG [\(self.lastSemaphore)] Set wrappedValue to \(expectedResult).")
                 self.onSet(expectedResult, .begin)
             }
         }
@@ -112,6 +113,11 @@ public class StateManager<Value: Equatable> {
         if lastSemaphore == semaphore {
             print("DEBUG [\(semaphore?.description ?? "nil")] is the last caller! Resetting lastVerifiedValue.")
             lastVerifiedValue = nil
+            if self.wrappedValue != newState {
+                print("DEBUG [\(semaphore?.description ?? "nil")] Unexpected value returned from API: \(newState)")
+                self.wrappedValue = newState
+                self.onSet(newState, .receive)
+            }
             return true
         }
         

--- a/Sources/MlemMiddleware/Content Models/StateManager.swift
+++ b/Sources/MlemMiddleware/Content Models/StateManager.swift
@@ -113,11 +113,6 @@ public class StateManager<Value: Equatable> {
         if lastSemaphore == semaphore {
             print("DEBUG [\(semaphore?.description ?? "nil")] is the last caller! Resetting lastVerifiedValue.")
             lastVerifiedValue = nil
-            if self.wrappedValue != newState {
-                print("DEBUG [\(semaphore?.description ?? "nil")] Unexpected value returned from API: \(newState)")
-                self.wrappedValue = newState
-                self.onSet(newState, .receive)
-            }
             return true
         }
         

--- a/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
+++ b/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
@@ -27,29 +27,23 @@ internal struct SubscriptionModel: Hashable, Equatable {
     var pending: Bool
     
     // This accounts for the `actualTotal` not taking your own pending subscription into account.
-    var total: Int {
-        switch (subscribed, pending) {
-        case (true, true):
-            return actualTotal + 1
-        case (false, true):
-            return actualTotal - 1
-        case (_, false):
-            return actualTotal
-        }
-    }
+    var total: Int { actualTotal + pendingSubscriptionValue }
     
     // This accounts for the `actualLocal` not taking your own pending subscription into account.
     /// Added in 0.19.4.
-    func local(communityIsLocal: Bool) -> Int? {
+    var local: Int? {
         guard let actualLocal else { return nil }
-        if !communityIsLocal { return actualLocal }
+        return actualLocal + pendingSubscriptionValue
+    }
+    
+    private var pendingSubscriptionValue: Int {
         switch (subscribed, pending) {
         case (true, true):
-            return actualLocal + 1
+            return 1
         case (false, true):
-            return actualLocal - 1
+            return -1
         case (_, false):
-            return actualLocal
+            return 0
         }
     }
     

--- a/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
+++ b/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
@@ -15,10 +15,11 @@ internal struct SubscriptionModel: Hashable, Equatable {
     var subscribed: Bool
     
     // When you subscribe, your instance asks the community host to confirm the subscription.
-    // Until a confirmation is received from the host, `ApiSubscribedType.pending` is returned.
-    // The subscription count of the community doesn't change until the subscription status
-    // is confirmed by the community host. There also appears to exist a "pending" state for
-    // unsubscribing, but the API doesn't tell us when it's in this state.
+    // Until a confirmation is received from the host, the subscription state is
+    // `ApiSubscribedType.pending`. The subscription count of the community doesn't change
+    // until the subscription status is confirmed by the community host. There also appears
+    // to exist a "pending" state for unsubscribing, but the API doesn't tell us when it's
+    // in this state.
     //
     // This property is "true" when the subscription is thought to be pending in **either**
     // direction. Because we don't actually know whether an unsubscription is pending, this

--- a/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
+++ b/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
@@ -1,0 +1,97 @@
+//
+//  SubscriptionModel.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 08/08/2024.
+//
+
+import Foundation
+
+internal struct SubscriptionModel: Hashable, Equatable {
+    // These are the values actually provided by the API.
+    private var actualTotal: Int
+    private var actualLocal: Int?
+    
+    private var subscribedType: ApiSubscribedType
+    
+    var subscribed: Bool { subscribedType != .notSubscribed }
+    var pending: Bool { subscribedType == .pending }
+    
+    // This accounts for the `actualTotal` not taking your own pending subscription into account.
+    var total: Int {
+        subscribedType == .pending ? (actualTotal + 1) : actualTotal
+    }
+    
+    // This accounts for the `actualLocal` not taking your own pending subscription into account.
+    /// Added in 0.19.4.
+    var local: Int? {
+        guard let actualLocal else { return nil }
+        return subscribedType == .pending ? (actualLocal + 1) : actualLocal
+    }
+    
+    init(from aggregates: ApiCommunityAggregates, subscribedType: ApiSubscribedType) {
+        self.actualTotal = aggregates.subscribers
+        self.actualLocal = aggregates.subscribersLocal
+        self.subscribedType = subscribedType
+    }
+    
+    init(total: Int, local: Int? = nil, subscribedType: ApiSubscribedType) {
+        self.actualTotal = total
+        self.actualLocal = local
+        self.subscribedType = subscribedType
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(total)
+        hasher.combine(local)
+        hasher.combine(subscribedType)
+    }
+    
+    static func == (lhs: SubscriptionModel, rhs: SubscriptionModel) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+extension SubscriptionModel {
+    func withSubscriptionStatus(subscribed shouldSubscribe: Bool, isLocal: Bool) -> SubscriptionModel {
+        guard shouldSubscribe != self.subscribed else { return self }
+        
+        let newSubscribedType: ApiSubscribedType
+        if shouldSubscribe {
+            // When you subscribe, your instance asks the community host to confirm the subscription.
+            // Until a confirmation is received from the host, `.pending` is returned. Therefore we
+            // assume `.pending` will be returned for non-local communities when state-faking the status.
+            // The subscription count doesn't change either until the subscription status is confirmed
+            // by the community host.
+            newSubscribedType = isLocal ? .subscribed : .pending
+        } else {
+            newSubscribedType = .notSubscribed
+        }
+        
+        let diff: Int
+        switch newSubscribedType {
+        case .notSubscribed:
+            // It appears there is also a "pending" state when unsubscribing, but we don't get to know
+            // when it's in this state. The consequence of this is that the count may not update when
+            // unsubscribing until confirmation is received.
+            diff = isLocal ? -1 : 0
+        case .pending:
+            diff = 0
+        case .subscribed:
+            diff = 1
+        }
+        
+        let newLocal: Int?
+        if let actualLocal {
+            newLocal = isLocal ? (actualLocal + diff) : actualLocal
+        } else {
+            newLocal = nil
+        }
+        
+        return SubscriptionModel(
+            total: actualTotal + diff,
+            local: newLocal,
+            subscribedType: newSubscribedType
+        )
+    }
+}

--- a/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
+++ b/Sources/MlemMiddleware/Content Models/SubscriptionModel.swift
@@ -24,9 +24,9 @@ internal struct SubscriptionModel: Hashable, Equatable {
     
     // This accounts for the `actualLocal` not taking your own pending subscription into account.
     /// Added in 0.19.4.
-    var local: Int? {
+    func local(communityIsLocal: Bool) -> Int? {
         guard let actualLocal else { return nil }
-        return subscribedType == .pending ? (actualLocal + 1) : actualLocal
+        return (communityIsLocal && subscribedType == .pending) ? (actualLocal + 1) : actualLocal
     }
     
     init(from aggregates: ApiCommunityAggregates, subscribedType: ApiSubscribedType) {
@@ -42,8 +42,8 @@ internal struct SubscriptionModel: Hashable, Equatable {
     }
     
     func hash(into hasher: inout Hasher) {
-        hasher.combine(total)
-        hasher.combine(local)
+        hasher.combine(actualTotal)
+        hasher.combine(actualLocal)
         hasher.combine(subscribedType)
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoadingState.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoadingState.swift
@@ -10,6 +10,6 @@ import Foundation
 /// - idle: not currently loading, but more items available to load
 /// - loading: currently loading more items
 /// - done: no more items available to load
-public enum LoadingState {
+public enum LoadingState: Hashable {
     case idle, loading, done
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/AggregatePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/AggregatePostFeedLoader.swift
@@ -37,7 +37,7 @@ public class AggregatePostFeedLoader: CorePostFeedLoader {
     override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
         return try await api.getPosts(
             feed: feedType,
-            sort: postSortType,
+            sort: sortType,
             page: page,
             cursor: cursor,
             limit: pageSize,

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CommunityPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CommunityPostFeedLoader.swift
@@ -33,7 +33,7 @@ public class CommunityPostFeedLoader: CorePostFeedLoader {
     
     override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
         return try await community.getPosts(
-            sort: postSortType,
+            sort: sortType,
             page: page,
             cursor: cursor,
             limit: pageSize,

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
@@ -12,7 +12,7 @@ import Observation
 /// Post tracker for use with single feeds. Can easily be extended to load any pure post feed by creating an inheriting class that overrides getPosts().
 @Observable
 public class CorePostFeedLoader: StandardFeedLoader<Post2> {
-    private(set) var postSortType: ApiSortType
+    public private(set) var sortType: ApiSortType
     
     // prefetching
     private let smallAvatarIconSize: Int
@@ -31,7 +31,7 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
         smallAvatarSize: CGFloat,
         largeAvatarSize: CGFloat
     ) {
-        self.postSortType = sortType
+        self.sortType = sortType
     
         self.smallAvatarIconSize = Int(smallAvatarSize * 2)
         self.largeAvatarIconSize = Int(largeAvatarSize * 2)
@@ -73,11 +73,11 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     /// Changes the post sort type to the specified value and reloads the feed
     public func changeSortType(to newSortType: ApiSortType, forceRefresh: Bool = false) async throws {
         // don't do anything if sort type not changed
-        guard postSortType != newSortType || forceRefresh else {
+        guard sortType != newSortType || forceRefresh else {
             return
         }
         
-        postSortType = newSortType
+        sortType = newSortType
         try await refresh(clearBeforeRefresh: true)
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
@@ -12,7 +12,7 @@ import Observation
 /// Post tracker for use with single feeds. Can easily be extended to load any pure post feed by creating an inheriting class that overrides getPosts().
 @Observable
 public class CorePostFeedLoader: StandardFeedLoader<Post2> {
-    public private(set) var sortType: ApiSortType
+    public var sortType: ApiSortType
     
     // prefetching
     private let smallAvatarIconSize: Int


### PR DESCRIPTION
The community subscription count is now state-faked together with the subscription status in a `SubscriptionModel`. This is similar to how vote status is combined with vote count in `VotesModel`. This means that when you subscribe to a community, you can see the count change immediately.

Also made some tweaks to the feed loader