### PR TITLE
Prefetching changes

### DIFF
--- a/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
@@ -103,9 +103,14 @@ public extension Post1Providing {
         // post with URL: either image or link
         if let linkUrl {
             // if image, return image link, otherwise return thumbnail
-            return linkUrl.isImage ? 
-                .image(linkUrl) :
-                .link(.init(content: linkUrl, thumbnail: thumbnailUrl, label: embed?.title ?? title))
+            if linkUrl.isImage {
+                if let thumbnailUrl {
+                    // lemmy-ui always shows the `thumbnailUrl` if available even in expanded view
+                    return .image(thumbnailUrl)
+                }
+                return .image(linkUrl)
+            }
+            return .link(.init(content: linkUrl, thumbnail: thumbnailUrl, label: embed?.title ?? title))
         }
 
         // otherwise text, but post.body needs to be present, even if it's an empty string

--- a/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
+++ b/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
@@ -13,10 +13,9 @@ extension URL: Identifiable {
 
 public extension URL {
     // Spec described here: https://join-lemmy.org/docs/contributors/04-api.html#images
-    func withIconSize(_ size: Int) -> URL {
-        var result = self
-        result.append(queryItems: [URLQueryItem(name: "thumbnail", value: "\(size)")])
-        return result
+    func withIconSize(_ size: Int?) -> URL {
+        guard let size else { return self }
+        return appending(queryItems: [URLQueryItem(name: "thumbnail", value: "\(size)")])
     }
     
     func removingPathComponents() -> URL {

--- a/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
+++ b/Sources/MlemMiddleware/Extensions/URL+Extensions.swift
@@ -15,7 +15,15 @@ public extension URL {
     // Spec described here: https://join-lemmy.org/docs/contributors/04-api.html#images
     func withIconSize(_ size: Int?) -> URL {
         guard let size else { return self }
-        return appending(queryItems: [URLQueryItem(name: "thumbnail", value: "\(size)")])
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
+            print("Failed to create URLComponents")
+            return self.appending(queryItems: [.init(name: "thumbnail", value: String(size))])
+        }
+        var queryItems = components.queryItems ?? []
+        queryItems.removeFirst(where: { $0.name == "thumbnail" })
+        queryItems.append(.init(name: "thumbnail", value: String(size)))
+        components.queryItems = queryItems
+        return components.url ?? self
     }
     
     func removingPathComponents() -> URL {

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/AggregatePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/AggregatePostFeedLoader.swift
@@ -16,8 +16,7 @@ public class AggregatePostFeedLoader: CorePostFeedLoader {
         sortType: ApiSortType,
         showReadPosts: Bool,
         filteredKeywords: [String],
-        smallAvatarSize: CGFloat,
-        largeAvatarSize: CGFloat,
+        prefetchingConfiguration: PrefetchingConfiguration,
         urlCache: URLCache,
         api: ApiClient,
         feedType: ApiListingType
@@ -29,8 +28,7 @@ public class AggregatePostFeedLoader: CorePostFeedLoader {
             sortType: sortType,
             showReadPosts: showReadPosts,
             filteredKeywords: filteredKeywords,
-            smallAvatarSize: smallAvatarSize,
-            largeAvatarSize: largeAvatarSize
+            prefetchingConfiguration: prefetchingConfiguration
         )
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CommunityPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CommunityPostFeedLoader.swift
@@ -15,8 +15,7 @@ public class CommunityPostFeedLoader: CorePostFeedLoader {
         sortType: ApiSortType,
         showReadPosts: Bool,
         filteredKeywords: [String],
-        smallAvatarSize: CGFloat,
-        largeAvatarSize: CGFloat,
+        prefetchingConfiguration: PrefetchingConfiguration,
         urlCache: URLCache,
         community: any Community
     ) {
@@ -26,8 +25,7 @@ public class CommunityPostFeedLoader: CorePostFeedLoader {
             sortType: sortType,
             showReadPosts: showReadPosts,
             filteredKeywords: filteredKeywords,
-            smallAvatarSize: smallAvatarSize,
-            largeAvatarSize: largeAvatarSize
+            prefetchingConfiguration: prefetchingConfiguration
         )
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
@@ -12,29 +12,26 @@ import Observation
 /// Post tracker for use with single feeds. Can easily be extended to load any pure post feed by creating an inheriting class that overrides getPosts().
 @Observable
 public class CorePostFeedLoader: StandardFeedLoader<Post2> {
-    private(set) var postSortType: ApiSortType
     
     // prefetching
-    private let smallAvatarIconSize: Int
-    private let largeAvatarIconSize: Int
     private let prefetcher: ImagePrefetcher = .init(
         pipeline: ImagePipeline.shared,
         destination: .memoryCache,
         maxConcurrentRequestCount: 40
     )
+
+    private(set) var postSortType: ApiSortType
+    public private(set) var prefetchingConfiguration: PrefetchingConfiguration
     
     public init(
         pageSize: Int,
         sortType: ApiSortType,
         showReadPosts: Bool,
         filteredKeywords: [String],
-        smallAvatarSize: CGFloat,
-        largeAvatarSize: CGFloat
+        prefetchingConfiguration: PrefetchingConfiguration
     ) {
         self.postSortType = sortType
-    
-        self.smallAvatarIconSize = Int(smallAvatarSize * 2)
-        self.largeAvatarIconSize = Int(largeAvatarSize * 2)
+        self.prefetchingConfiguration = prefetchingConfiguration
         
         super.init(
             pageSize: pageSize,
@@ -106,10 +103,13 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     
     /// Preloads images for the given post
     private func preloadImages(_ posts: [Post2]) {
-        prefetcher.startPrefetching(with: posts.flatMap { 
-            $0.imageRequests(
-                smallAvatarIconSize: smallAvatarIconSize,
-                largeAvatarIconSize: largeAvatarIconSize)
+        prefetchingConfiguration.prefetcher.startPrefetching(with: posts.flatMap {
+            $0.imageRequests(configuration: prefetchingConfiguration)
         })
+    }
+    
+    public func setPrefetchingConfiguration(_ config: PrefetchingConfiguration) {
+        prefetchingConfiguration = config
+        preloadImages(items)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/PrefetchingConfiguration.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/PrefetchingConfiguration.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 10/08/2024.
+//
+
+import Foundation
+import Nuke
+
+public struct PrefetchingConfiguration {
+    public enum ImageResolution {
+        case unlimited, limited(Int)
+    }
+    
+    public var prefetcher: ImagePrefetcher
+    
+    public var imageSize: ImageResolution
+    
+    /// If `nil`, does not fetch avatars.
+    public var avatarSize: Int?
+    
+    public init(
+        prefetcher: ImagePrefetcher,
+        imageSize: ImageResolution,
+        avatarSize: Int? = nil
+    ) {
+        self.prefetcher = prefetcher
+        self.imageSize = imageSize
+        self.avatarSize = avatarSize
+    }
+}

--- a/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
@@ -29,14 +29,7 @@ public class PersonContentFeedLoader: FeedLoading {
     private var userId: Int
     private var savedOnly: Bool
     
-    // prefetching
-    private let smallAvatarIconSize: Int
-    private let largeAvatarIconSize: Int
-    private let prefetcher: ImagePrefetcher = .init(
-        pipeline: ImagePipeline.shared,
-        destination: .memoryCache,
-        maxConcurrentRequestCount: 40
-    )
+    public var prefetchingConfiguration: PrefetchingConfiguration
     
     /// Last page fetched from the API
     internal var apiPage: Int
@@ -61,8 +54,7 @@ public class PersonContentFeedLoader: FeedLoading {
         userId: Int,
         sortType: FeedLoaderSort.SortType,
         savedOnly: Bool,
-        smallAvatarSize: CGFloat,
-        largeAvatarSize: CGFloat,
+        prefetchingConfiguration: PrefetchingConfiguration,
         withContent: (posts: [Post2], comments: [Comment2])? = nil
     ) {
         self.api = api
@@ -76,8 +68,7 @@ public class PersonContentFeedLoader: FeedLoading {
         self.loadingState = .idle
         self.postStream = .init(items: withContent?.posts)
         self.commentStream = .init(items: withContent?.comments)
-        self.smallAvatarIconSize = Int(smallAvatarSize * 2)
-        self.largeAvatarIconSize = Int(largeAvatarSize * 2)
+        self.prefetchingConfiguration = prefetchingConfiguration
     }
     
     // MARK: Public Methods
@@ -245,10 +236,8 @@ public class PersonContentFeedLoader: FeedLoading {
     
     /// Preloads images for the given post
     private func preloadImages(_ posts: [Post2]) {
-        prefetcher.startPrefetching(with: posts.flatMap {
-            $0.imageRequests(
-                smallAvatarIconSize: smallAvatarIconSize,
-                largeAvatarIconSize: largeAvatarIconSize)
+        prefetchingConfiguration.prefetcher.startPrefetching(with: posts.flatMap {
+            $0.imageRequests(configuration: prefetchingConfiguration)
         })
     }
 }


### PR DESCRIPTION
Made prefetching more customizable. From Mlem, you can can now:
- Set the size of the main post image
- Choose not to prefetch avatar images
- Provide a different Nuke `ImagePrefetcher` if needed