### PR TITLE
Fix FeedLoader early stop

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -124,7 +124,7 @@ public class ApiClient {
     func perform<Request: ApiRequest>(_ request: Request) async throws -> Request.Response {
         let urlRequest = try urlRequest(from: request)
         // this line intentionally left commented for convenient future debugging
-        // urlRequest.debug()
+        urlRequest.debug()
         let (data, response) = try await execute(urlRequest)
         if let response = response as? HTTPURLResponse {
             if response.statusCode >= 500 { // Error code for server being offline.

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -124,7 +124,7 @@ public class ApiClient {
     func perform<Request: ApiRequest>(_ request: Request) async throws -> Request.Response {
         let urlRequest = try urlRequest(from: request)
         // this line intentionally left commented for convenient future debugging
-        urlRequest.debug()
+        // urlRequest.debug()
         let (data, response) = try await execute(urlRequest)
         if let response = response as? HTTPURLResponse {
             if response.statusCode >= 500 { // Error code for server being offline.

--- a/Sources/MlemMiddleware/API Client/Caching/CoreCache.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/CoreCache.swift
@@ -34,7 +34,7 @@ open class CoreCache<Content: CacheIdentifiable & AnyObject> {
         }
         
         public func remove(_ cacheId: Int) {
-            print("Removed \(cacheId)")
+            // print("Removed \(cacheId)")
             cachedItems.value[cacheId] = nil
         }
         

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -118,8 +118,6 @@ public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
             print("[\(Item.self) tracker] loading cursor \(cursorToLoad)")
             try await loadCursorHelper(cursorToLoad)
         }
-        
-        print("[\(Item.self) tracker] finished \(action)")
     }
     
     /// Fetches the given page of items. This method must be overridden by the instantiating class because different items are loaded differently. The instantiating class is responsible for handling fetch parameters (e.g., page size, unread only) and performing filtering
@@ -169,8 +167,6 @@ public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
     /// - Parameter pageToLoad: page to load
     /// - Warning: **DO NOT** call this method from anywhere but `load`! This is *purely* a helper function for `load` and *will* lead to unexpected behavior if called elsewhere!
     private func loadPageHelper(_ pageToLoad: Int) async throws {
-        print("[\(Item.self) tracker] loading page \(pageToLoad)")
-        
         // There isn't a scenario in which we have cursor available but want to load a specific page of content; either we are loading the first
         // page or the cursor is unavailable.
         assert(loadingCursor == nil || pageToLoad == 1, "loadPageHelper called when valid cursor available!")
@@ -226,8 +222,6 @@ public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
     }
     
     private func loadCursorHelper(_ cursor: String) async throws {
-        print("[\(Item.self) tracker] loading cursor \(cursor)")
-        
         // do not continue to load if done
         guard loadingState != .done else {
             print("[\(Item.self) tracker] done loading, will not continue")

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -187,16 +187,16 @@ public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
         
         var newState: LoadingState = .idle
         
-        // var cursor: String? = nil // used to track
         var newItems: [Item] = .init()
         while newItems.count < pageSize {
-            // use cursor-based fetching if a cursor was returned from the
+            // use cursor-based fetching if available
             let fetched: FetchResponse<Item>
             if let loadingCursor {
                 fetched = try await fetchCursor(cursor: loadingCursor)
             } else {
                 fetched = try await fetchPage(page: page + 1)
             }
+            
             page += 1
             loadingCursor = fetched.nextCursor
             

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -187,18 +187,18 @@ public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
         
         var newState: LoadingState = .idle
         
-        var cursor: String? = nil // used to track
+        // var cursor: String? = nil // used to track
         var newItems: [Item] = .init()
         while newItems.count < pageSize {
             // use cursor-based fetching if a cursor was returned from the
             let fetched: FetchResponse<Item>
-            if let cursor {
-                fetched = try await fetchCursor(cursor: cursor)
+            if let loadingCursor {
+                fetched = try await fetchCursor(cursor: loadingCursor)
             } else {
                 fetched = try await fetchPage(page: page + 1)
             }
             page += 1
-            cursor = fetched.nextCursor
+            loadingCursor = fetched.nextCursor
             
             if !fetched.hasContent {
                 print("[\(Item.self) tracker] fetch returned no items, setting loading state to done")
@@ -208,8 +208,6 @@ public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
             
             newItems.append(contentsOf: fetched.items)
         }
-        
-        loadingCursor = cursor
 
         // if loading page 1, we can just do a straight assignment regardless of whether we did clearBeforeReset
         if pageToLoad == 1 {

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
@@ -39,9 +39,7 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     
     override public func fetchPage(page: Int) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: page, cursor: nil)
-        
-        print("[\(Item.self) tracker] fetching page \(page) returned \(result.posts.count) posts, next cursor \(result.cursor)")
-        
+
         let filteredPosts = filter.filter(result.posts)
         preloadImages(filteredPosts)
         return .init(
@@ -54,9 +52,7 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     
     override public func fetchCursor(cursor: String?) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: page, cursor: cursor)
-        
-        print("[\(Item.self) tracker] fetching cursor \(cursor) returned \(result.posts.count) posts, next cursor \(result.cursor)")
-        
+
         let filteredPosts = filter.filter(result.posts)
         preloadImages(filteredPosts)
         return .init(

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feeed Loaders/CorePostFeedLoader.swift
@@ -40,17 +40,31 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     override public func fetchPage(page: Int) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: page, cursor: nil)
         
+        print("[\(Item.self) tracker] fetching page \(page) returned \(result.posts.count) posts, next cursor \(result.cursor)")
+        
         let filteredPosts = filter.filter(result.posts)
         preloadImages(filteredPosts)
-        return .init(items: filteredPosts, cursor: result.cursor, numFiltered: result.posts.count - filteredPosts.count)
+        return .init(
+            items: filteredPosts,
+            prevCursor: nil,
+            nextCursor: result.cursor,
+            numFiltered: result.posts.count - filteredPosts.count
+        )
     }
     
     override public func fetchCursor(cursor: String?) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: page, cursor: cursor)
         
+        print("[\(Item.self) tracker] fetching cursor \(cursor) returned \(result.posts.count) posts, next cursor \(result.cursor)")
+        
         let filteredPosts = filter.filter(result.posts)
         preloadImages(filteredPosts)
-        return .init(items: filteredPosts, cursor: result.cursor, numFiltered: result.posts.count - filteredPosts.count)
+        return .init(
+            items: filteredPosts,
+            prevCursor: cursor,
+            nextCursor: result.cursor,
+            numFiltered: result.posts.count - filteredPosts.count
+        )
     }
     
     internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {


### PR DESCRIPTION
Fixes a cluster of related cursor bugs:
- Fixes a bug in the cursor logic where the StandardFeedLoader would detect EOF prematurely. This was happening due to `cursor` being used for all fetches inside `loadCursorHelper` but not being updated.
- Fixes `fetchPageHelper` using page-based pagination for fetches after page 1 on instances which support cursor-based pagination. On such instances, page-based fetching is only used for the first page.
- Moves EOF cursor detection logic into `FetchResponse.hasContent`