### PR TITLE
`UnreadCount` reliability

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -88,7 +88,6 @@ public extension ApiClient {
     
     @discardableResult
     internal func refreshUnreadCount() async throws -> ApiGetUnreadCountResponse {
-        self.unreadCount?.beginUpdate()
         let request = GetUnreadCountRequest()
         let response = try await perform(request)
         await self.unreadCount?.update(with: response)

--- a/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -88,6 +88,7 @@ public extension ApiClient {
     
     @discardableResult
     internal func refreshUnreadCount() async throws -> ApiGetUnreadCountResponse {
+        self.unreadCount?.beginUpdate()
         let request = GetUnreadCountRequest()
         let response = try await perform(request)
         await self.unreadCount?.update(with: response)

--- a/Sources/MlemMiddleware/Content Models/Community/Community1.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/Community1.swift
@@ -69,7 +69,7 @@ public final class Community1: Community1Providing {
         self.hidden = hidden
         self.onlyModeratorsCanPost = onlyModeratorsCanPost
         self.blockedManager = .init(wrappedValue: blocked ?? api.blocks?.communities.keys.contains(actorId) ?? false)
-        self.blockedManager.onSet = { newValue, type in
+        self.blockedManager.onSet = { newValue, type, _ in
             if type != .receive {
                 if newValue {
                     api.blocks?.communities[actorId] = id

--- a/Sources/MlemMiddleware/Content Models/Community/Community2.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/Community2.swift
@@ -47,10 +47,10 @@ public final class Community2: Community2Providing {
         if favorited, !subscribed {
             self.api.subscriptions?.favoriteIDs.remove(self.id)
         }
-        self.subscriptionManager.onSet = { _, _ in
+        self.subscriptionManager.onSet = { _, _, _ in
             self.api.subscriptions?.updateCommunitySubscription(community: self)
         }
         self.shouldBeFavorited = favorited
-        self.subscriptionManager.onSet(subscription, .receive)
+        self.subscriptionManager.onSet(subscription, .receive, nil)
     }
 }

--- a/Sources/MlemMiddleware/Content Models/Instance/Instance1.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/Instance1.swift
@@ -75,7 +75,7 @@ public final class Instance1: Instance1Providing {
         self.blockedManager = .init(
             wrappedValue: blocked ?? api.blocks?.instances.keys.contains(actorId) ?? false
         )
-        self.blockedManager.onSet = { newValue, type in
+        self.blockedManager.onSet = { newValue, type, _ in
             if type != .receive {
                 if newValue {
                     api.blocks?.instances[actorId] = instanceId

--- a/Sources/MlemMiddleware/Content Models/Message/Message1.swift
+++ b/Sources/MlemMiddleware/Content Models/Message/Message1.swift
@@ -49,10 +49,8 @@ public final class Message1: Message1Providing {
         self.created = created
         self.updated = updated
         self.readManager = .init(wrappedValue: read)
-        self.readManager.onSet = { newValue, type in
-            if type != .receive {
-                api.unreadCount?.messages += newValue ? -1 : 1
-            }
+        self.readManager.onSet = { newValue, type, semaphore in
+            api.unreadCount?.updateItem(itemType: .message, isRead: newValue, updateType: type, semaphore: semaphore)
         }
     }
 }

--- a/Sources/MlemMiddleware/Content Models/Message/Message1.swift
+++ b/Sources/MlemMiddleware/Content Models/Message/Message1.swift
@@ -50,7 +50,12 @@ public final class Message1: Message1Providing {
         self.updated = updated
         self.readManager = .init(wrappedValue: read)
         self.readManager.onSet = { newValue, type, semaphore in
-            api.unreadCount?.updateItem(itemType: .message, isRead: newValue, updateType: type, semaphore: semaphore)
+            if type == .begin || type == .rollback {
+                api.unreadCount?.updateUnverifiedItem(itemType: .message, isRead: newValue)
+            }
+        }
+        self.readManager.onVerify = { newValue, semaphore in
+            api.unreadCount?.verifyItem(itemType: .message, isRead: newValue)
         }
     }
 }

--- a/Sources/MlemMiddleware/Content Models/Person/Person1.swift
+++ b/Sources/MlemMiddleware/Content Models/Person/Person1.swift
@@ -68,7 +68,7 @@ public final class Person1: Person1Providing {
         self.isBot = isBot
         self.instanceBan = instanceBan
         self.blockedManager = .init(wrappedValue: blocked ?? api.blocks?.people.keys.contains(actorId) ?? false)
-        self.blockedManager.onSet = { newValue, type in
+        self.blockedManager.onSet = { newValue, type, _ in
             if type != .receive {
                 if newValue {
                     api.blocks?.people[actorId] = id

--- a/Sources/MlemMiddleware/Content Models/Reply/Reply1.swift
+++ b/Sources/MlemMiddleware/Content Models/Reply/Reply1.swift
@@ -40,19 +40,17 @@ public final class Reply1: Reply1Providing {
         self.isMention = isMention
         self.readManager = .init(wrappedValue: read)
         self.readManager.onSet = { newValue, type, semaphore in
-            api.unreadCount?.updateItem(
-                itemType: isMention ? .mention : .reply,
-                isRead: newValue,
-                updateType: type,
-                semaphore: semaphore
-            )
+            if type == .begin || type == .rollback {
+                api.unreadCount?.updateUnverifiedItem(
+                    itemType: isMention ? .mention : .reply,
+                    isRead: newValue
+                )
+            }
         }
         self.readManager.onVerify = { newValue, semaphore in
-            api.unreadCount?.updateItem(
+            api.unreadCount?.verifyItem(
                 itemType: isMention ? .mention : .reply,
-                isRead: newValue,
-                updateType: .receive,
-                semaphore: semaphore
+                isRead: newValue
             )
         }
     }

--- a/Sources/MlemMiddleware/Content Models/Reply/Reply1.swift
+++ b/Sources/MlemMiddleware/Content Models/Reply/Reply1.swift
@@ -39,14 +39,21 @@ public final class Reply1: Reply1Providing {
         self.created = created
         self.isMention = isMention
         self.readManager = .init(wrappedValue: read)
-        self.readManager.onSet = { newValue, type in
-            if type != .receive {
-                if isMention {
-                    api.unreadCount?.mentions += newValue ? -1 : 1
-                } else {
-                    api.unreadCount?.replies += newValue ? -1 : 1
-                }
-            }
+        self.readManager.onSet = { newValue, type, semaphore in
+            api.unreadCount?.updateItem(
+                itemType: isMention ? .mention : .reply,
+                isRead: newValue,
+                updateType: type,
+                semaphore: semaphore
+            )
+        }
+        self.readManager.onVerify = { newValue, semaphore in
+            api.unreadCount?.updateItem(
+                itemType: isMention ? .mention : .reply,
+                isRead: newValue,
+                updateType: .receive,
+                semaphore: semaphore
+            )
         }
     }
 }

--- a/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
@@ -106,11 +106,11 @@ public extension Reply1Providing {
     // This hopefully won't be needed once `UnreadCount` is properly state-faked
     internal func setKnownReadState(newValue: Bool) {
         readManager.updateWithReceivedValue(newValue, semaphore: nil)
-        if isMention {
-            api.unreadCount?.mentions += newValue ? -1 : 1
-        } else {
-            api.unreadCount?.replies += newValue ? -1 : 1
-        }
+//        if isMention {
+//            api.unreadCount?.mentions += newValue ? -1 : 1
+//        } else {
+//            api.unreadCount?.replies += newValue ? -1 : 1
+//        }
     }
 }
 

--- a/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
@@ -103,14 +103,13 @@ public extension Reply1Providing {
         try await api.reportComment(id: commentId, reason: reason)
     }
     
-    // This hopefully won't be needed once `UnreadCount` is properly state-faked
     internal func setKnownReadState(newValue: Bool) {
         readManager.updateWithReceivedValue(newValue, semaphore: nil)
-//        if isMention {
-//            api.unreadCount?.mentions += newValue ? -1 : 1
-//        } else {
-//            api.unreadCount?.replies += newValue ? -1 : 1
-//        }
+        if isMention {
+            api.unreadCount?.verifiedCount.mentions += newValue ? -1 : 1
+        } else {
+            api.unreadCount?.verifiedCount.replies += newValue ? -1 : 1
+        }
     }
 }
 

--- a/Sources/MlemMiddleware/Content Models/StateManager.swift
+++ b/Sources/MlemMiddleware/Content Models/StateManager.swift
@@ -114,12 +114,12 @@ public class StateManager<Value: Equatable> {
                 self.wrappedValue = newState
                 self.onSet(newState, .receive, semaphore)
             }
-            self.onVerify(newState, semaphore)
             return false
         }
         
         if lastSemaphore == semaphore {
             print("DEBUG [\(semaphore?.description ?? "nil")] is the last caller! Resetting lastVerifiedValue.")
+            self.onVerify(newState, semaphore)
             lastVerifiedValue = nil
             return true
         }

--- a/Sources/MlemMiddleware/Content Models/StateManager.swift
+++ b/Sources/MlemMiddleware/Content Models/StateManager.swift
@@ -60,7 +60,11 @@ public class StateManager<Value: Equatable> {
     /// The state-faked value that should be shown to the user.
     public private(set) var wrappedValue: Value
     
-    internal var onSet: (Value, _ type: StateManagerUpdateType) -> Void
+    /// Called when `wrappedValue` is changed.
+    internal var onSet: (Value, _ type: StateManagerUpdateType, _ semaphore: UInt?) -> Void
+    
+    /// Called whenever `wrappedValue` is verified.
+    internal var onVerify: (Value, _ semaphore: UInt?) -> Void
     
     /// Responsible for tracking who the most recent caller is. Every time the state is changed, `lastSemaphore` is incremented by one.
     private var lastSemaphore: UInt = 0
@@ -73,27 +77,30 @@ public class StateManager<Value: Equatable> {
     
     init(
         wrappedValue: Value,
-        onSet: @escaping (Value, _ type: StateManagerUpdateType) -> Void = { _, _ in }
+        onSet: @escaping (Value, _ type: StateManagerUpdateType, _ semaphore: UInt?) -> Void = { _, _, _ in },
+        onVerify: @escaping (Value, _ semaphore: UInt?) -> Void = { _, _ in }
     ) {
         self.wrappedValue = wrappedValue
         self.onSet = onSet
+        self.onVerify = onVerify
     }
         
     /// Call at the start of a voting operation, BEFORE state faking is performed. Updates the clean state if nil and increments semaphore.
     /// - Returns: new sempaphore value
     @discardableResult
     func beginOperation(expectedResult: Value, semaphore: UInt? = nil) -> UInt {
-        lastSemaphore = semaphore ?? SemaphoreServer.next()
-        print("DEBUG [\(lastSemaphore)] began operation.")
+        let semaphore = semaphore ?? SemaphoreServer.next()
+        self.lastSemaphore = semaphore
+        print("DEBUG [\(semaphore)] began operation.")
         if lastVerifiedValue == nil {
-            print("DEBUG [\(lastSemaphore)] Set lastVerifiedValue to \(wrappedValue).")
+            print("DEBUG [\(semaphore)] Set lastVerifiedValue to \(wrappedValue).")
             lastVerifiedValue = wrappedValue
         }
         DispatchQueue.main.async {
             if self.wrappedValue != expectedResult {
                 self.wrappedValue = expectedResult
-                print("DEBUG [\(self.lastSemaphore)] Set wrappedValue to \(expectedResult).")
-                self.onSet(expectedResult, .begin)
+                print("DEBUG [\(semaphore)] Set wrappedValue to \(expectedResult).")
+                self.onSet(expectedResult, .begin, semaphore)
             }
         }
         return lastSemaphore
@@ -105,8 +112,9 @@ public class StateManager<Value: Equatable> {
         if lastVerifiedValue == nil {
             if self.wrappedValue != newState {
                 self.wrappedValue = newState
-                self.onSet(newState, .receive)
+                self.onSet(newState, .receive, semaphore)
             }
+            self.onVerify(newState, semaphore)
             return false
         }
         
@@ -132,7 +140,7 @@ public class StateManager<Value: Equatable> {
             print("DEBUG [\(semaphore)] is the most recent caller! Resetting lastVerifiedValue.")
             if self.wrappedValue != lastVerifiedValue {
                 self.wrappedValue = lastVerifiedValue
-                self.onSet(lastVerifiedValue, .rollback)
+                self.onSet(lastVerifiedValue, .rollback, semaphore)
             }
             defer { self.lastVerifiedValue = nil }
             return lastVerifiedValue

--- a/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -27,7 +27,6 @@ public final class UnreadCount {
     public var total: Int { replies + mentions + messages }
     
     internal init(api: ApiClient) {
-        print("INIT UNREAD")
         self.api = api
     }
     
@@ -41,11 +40,9 @@ public final class UnreadCount {
             self.verifiedCount = .init(from: response)
             updateId += 1
         }
-        print("UnreadCount UPDT")
     }
     
     internal func clear() {
-        print("CLEAR")
         self.verifiedCount = .init()
         self.unverifiedCount = .init()
     }

--- a/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -24,20 +24,15 @@ public final class UnreadCount {
     /// refresh the inbox.
     public private(set) var updateId: UInt = 0
     
-    private var lastUpdateSemaphore: UInt = 0
-    
     public var total: Int { replies + mentions + messages }
     
     internal init(api: ApiClient) {
+        print("INIT UNREAD")
         self.api = api
     }
     
     public func refresh() async throws {
         try await self.api.refreshUnreadCount()
-    }
-    
-    internal func beginUpdate() {
-        lastUpdateSemaphore = SemaphoreServer.next()
     }
     
     @MainActor
@@ -50,21 +45,22 @@ public final class UnreadCount {
     }
     
     internal func clear() {
+        print("CLEAR")
         self.verifiedCount = .init()
         self.unverifiedCount = .init()
     }
     
-    internal func updateItem(itemType: InboxItemType, isRead: Bool, updateType: StateManagerUpdateType, semaphore: UInt?) {
-        // print("SEM", isRead, semaphore, lastUpdateSemaphore)
-//        if let semaphore, semaphore < lastUpdateSemaphore { return }
+    internal func updateUnverifiedItem(itemType: InboxItemType, isRead: Bool) {
         let diff = isRead ? -1 : 1
-        switch updateType {
-        case .begin, .rollback:
-            self.unverifiedCount[itemType] += diff
-        case .receive:
-            self.unverifiedCount[itemType] += diff
-            self.verifiedCount[itemType] -= diff
-        }
+        print("UP", itemType, isRead)
+        self.unverifiedCount[itemType] += diff
+    }
+    
+    internal func verifyItem(itemType: InboxItemType, isRead: Bool) {
+        let diff = isRead ? -1 : 1
+        print("VERIFY", itemType, isRead)
+        self.verifiedCount[itemType] += diff
+        self.unverifiedCount[itemType] -= diff
     }
 }
 

--- a/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -11,8 +11,8 @@ import Foundation
 public final class UnreadCount {
     public let api: ApiClient
     
-    private var verifiedCount: Counts = .init()
-    private var unverifiedCount: Counts = .init()
+    internal var verifiedCount: UnreadCountValues = .init()
+    internal var unverifiedCount: UnreadCountValues = .init()
     
     public var replies: Int { verifiedCount.replies + unverifiedCount.replies }
     public var mentions: Int { verifiedCount.mentions + unverifiedCount.mentions }
@@ -52,40 +52,30 @@ public final class UnreadCount {
     
     internal func updateUnverifiedItem(itemType: InboxItemType, isRead: Bool) {
         let diff = isRead ? -1 : 1
-        print("UP", itemType, isRead)
         self.unverifiedCount[itemType] += diff
     }
     
     internal func verifyItem(itemType: InboxItemType, isRead: Bool) {
         let diff = isRead ? -1 : 1
-        print("VERIFY", itemType, isRead)
         self.verifiedCount[itemType] += diff
         self.unverifiedCount[itemType] -= diff
     }
 }
 
-// Send count
-// Send mark (updates unread count)
-// Server recv count, sends back
-// Server recv mark, sends back
-// Recv count
-// Recv mark
-// Count does not include updated mark
-
-private struct Counts: Equatable {
+internal struct UnreadCountValues: Equatable {
     var replies: Int = 0
     var mentions: Int = 0
     var messages: Int = 0
 }
 
-extension Counts {
+extension UnreadCountValues {
     init(from response: ApiGetUnreadCountResponse) {
         self.replies = response.replies
         self.mentions = response.mentions
         self.messages = response.privateMessages
     }
     
-    public static func + (lhs: Counts, rhs: Counts) -> Counts {
+    public static func + (lhs: Self, rhs: Self) -> Self {
         return .init(
             replies: lhs.replies + rhs.replies,
             mentions: lhs.mentions + rhs.mentions,

--- a/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -9,26 +9,22 @@ import Foundation
 
 @Observable
 public final class UnreadCount {
-    // I haven't properly stress-tested this stake-faking system just yet.
-    // There is probably a failure case when an unread count update happens
-    // at the same time as a stake-fake, causing an `UnreadCount` value to be
-    // incorrect. This can probably be fixed using some sort of semaphore
-    // system. I think it's fine to leave this out of the first beta in the
-    // interest of time but will properly implement it sometime down the road.
-    // If the bug happens, it will resolve itself in 30s when the next inbox
-    // count is fetched.
-    
     public let api: ApiClient
     
-    public internal(set) var replies: Int = 0
-    public internal(set) var mentions: Int = 0
-    public internal(set) var messages: Int = 0
+    private var verifiedCount: Counts = .init()
+    private var unverifiedCount: Counts = .init()
+    
+    public var replies: Int { verifiedCount.replies + unverifiedCount.replies }
+    public var mentions: Int { verifiedCount.mentions + unverifiedCount.mentions }
+    public var messages: Int { verifiedCount.messages + unverifiedCount.messages }
     
     /// This value is incremented whenever the inbox count changes due to an
     /// updated unread count being fetched from the API. It is not incremented when
-    /// state-faking is performed. This can be used as a trigger to decide  when to
+    /// state-faking is performed. This can be used as a trigger to decide when to
     /// refresh the inbox.
-    public private(set) var updateId: Int = 0
+    public private(set) var updateId: UInt = 0
+    
+    private var lastUpdateSemaphore: UInt = 0
     
     public var total: Int { replies + mentions + messages }
     
@@ -40,23 +36,85 @@ public final class UnreadCount {
         try await self.api.refreshUnreadCount()
     }
     
+    internal func beginUpdate() {
+        lastUpdateSemaphore = SemaphoreServer.next()
+    }
+    
     @MainActor
     internal func update(with response: ApiGetUnreadCountResponse) {
-        if [
-            self.replies, self.mentions, self.messages
-        ] != [
-            response.replies, response.mentions, response.privateMessages
-        ] {
+        if self.verifiedCount != .init(from: response) {
+            self.verifiedCount = .init(from: response)
             updateId += 1
         }
+        print("UnreadCount UPDT")
+    }
+    
+    internal func clear() {
+        self.verifiedCount = .init()
+        self.unverifiedCount = .init()
+    }
+    
+    internal func updateItem(itemType: InboxItemType, isRead: Bool, updateType: StateManagerUpdateType, semaphore: UInt?) {
+        // print("SEM", isRead, semaphore, lastUpdateSemaphore)
+//        if let semaphore, semaphore < lastUpdateSemaphore { return }
+        let diff = isRead ? -1 : 1
+        switch updateType {
+        case .begin, .rollback:
+            self.unverifiedCount[itemType] += diff
+        case .receive:
+            self.unverifiedCount[itemType] += diff
+            self.verifiedCount[itemType] -= diff
+        }
+    }
+}
+
+// Send count
+// Send mark (updates unread count)
+// Server recv count, sends back
+// Server recv mark, sends back
+// Recv count
+// Recv mark
+// Count does not include updated mark
+
+private struct Counts: Equatable {
+    var replies: Int = 0
+    var mentions: Int = 0
+    var messages: Int = 0
+}
+
+extension Counts {
+    init(from response: ApiGetUnreadCountResponse) {
         self.replies = response.replies
         self.mentions = response.mentions
         self.messages = response.privateMessages
     }
     
-    internal func clear() {
-        self.replies = 0
-        self.mentions = 0
-        self.messages = 0
+    public static func + (lhs: Counts, rhs: Counts) -> Counts {
+        return .init(
+            replies: lhs.replies + rhs.replies,
+            mentions: lhs.mentions + rhs.mentions,
+            messages: lhs.messages + rhs.messages
+        )
     }
+    
+    subscript (type: InboxItemType) -> Int {
+        get {
+            switch type {
+            case .reply: replies
+            case .mention: mentions
+            case .message: messages
+            }
+        }
+        set {
+            switch type {
+            case .reply: replies = newValue
+            case .mention: mentions = newValue
+            case .message: messages = newValue
+            }
+        }
+    }
+}
+
+internal enum InboxItemType {
+    case reply, mention, message
 }


### PR DESCRIPTION
Fixed a bug where the inbox refresh popup was incorrectly shown if you happened to mark an item as read at the same time as the count was refreshing.

Non-breaking