### PR TITLE
0.18x Compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -17,6 +17,15 @@
         "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
         "version" : "0.0.8"
       }
+    },
+    {
+      "identity" : "swiftyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftyJSON/SwiftyJSON.git",
+      "state" : {
+        "revision" : "2b6054efa051565954e1d2b9da831680026cd768",
+        "version" : "4.3.0"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/groue/Semaphore.git", .upToNextMajor(from: "0.0.8")),
-        .package(url: "https://github.com/kean/Nuke.git", .upToNextMajor(from: "12.6.0"))
+        .package(url: "https://github.com/kean/Nuke.git", .upToNextMajor(from: "12.6.0")),
+        .package(url: "https://github.com/SwiftyJSON/SwiftyJSON.git", .upToNextMajor(from: "4.0.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -23,7 +24,8 @@ let package = Package(
             name: "MlemMiddleware",
             dependencies: [
                 .product(name: "Semaphore", package: "Semaphore"),
-                .product(name: "Nuke", package: "Nuke")
+                .product(name: "Nuke", package: "Nuke"),
+                .product(name: "SwiftyJSON", package: "SwiftyJSON")
             ],
             swiftSettings: [.enableUpcomingFeature("BareSlashRegexLiterals")]
         ),

--- a/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -117,7 +117,7 @@ public extension ApiClient {
         // We *must* use `postId` in 0.18 versions, and we *must* use `postIds` from 0.19.4 onwards.
         // On versions 0.19.0 to 0.19.3, either parameter is allowed.
         let request: MarkPostAsReadRequest
-        if try await batchMarkReadEnabled {
+        if try await supports(.batchMarkRead) {
             try await self.markPostsAsRead(
                 ids: [id],
                 read: read,

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -167,7 +167,16 @@ public class ApiClient {
         // need to use fetched
         // if version < .v19_0, let token, let httpBody = urlRequest.httpBody {
         
-        if urlRequest.httpMethod != "GET", fetchedVersion ?? .v18_0 < .v19_0, let token {
+        let apiVersionRecognized: Bool
+        if case .other = fetchedVersion {
+            apiVersionRecognized = false
+        } else {
+            apiVersionRecognized = true
+        }
+
+        if urlRequest.httpMethod != "GET",
+           !apiVersionRecognized || fetchedVersion ?? .v18_0 < .v19_0,
+           let token {
             let authBody: JSON = .init(dictionaryLiteral: ("auth", token))
             let newBody: JSON
             if let httpBody = urlRequest.httpBody {
@@ -195,7 +204,7 @@ public class ApiClient {
             }
         }
     }
-
+    
     func urlRequest(from definition: any ApiRequest) throws -> URLRequest {
         guard permissions != .none else { throw ApiClientError.insufficientPermissions }
         let url = definition.endpoint(base: endpointUrl)
@@ -213,7 +222,7 @@ public class ApiClient {
             urlRequest.httpMethod = "PUT"
             urlRequest.httpBody = try createBodyData(for: putDefinition)
         }
-
+        
         if let token, permissions == .all {
             // TODO: 0.18 deprecation remove this
             urlRequest.url?.append(queryItems: [.init(name: "auth", value: token)])

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -161,8 +161,13 @@ public class ApiClient {
     
     private func execute(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
         print("DEBUG executing...")
+        
+        let version = try await version
+        
+        print("DEBUG got version \(version  )")
+        
         // add 0.18x "auth" param if on 18.x instance and token defined
-        if try await version < .v19_0, let token, let httpBody = urlRequest.httpBody {
+        if version < .v19_0, let token, let httpBody = urlRequest.httpBody {
             var body = JSON(httpBody)
             print("DEBUG \(body)")
             body = try body.merged(with: JSON.init(dictionaryLiteral: ("auth", token)))

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -161,13 +161,13 @@ public class ApiClient {
     
     private func execute(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
         var urlRequest: URLRequest = urlRequest // make mutable
-        print("DEBUG executing...")
+        print("DEBUG executing \(urlRequest.httpMethod)...")
         
         // add 0.18x "auth" param if on 18.x instance and token defined
         // need to use fetched
         // if version < .v19_0, let token, let httpBody = urlRequest.httpBody {
         
-        if fetchedVersion ?? .v18_0 < .v19_0, let token {
+        if urlRequest.httpMethod != "GET", fetchedVersion ?? .v18_0 < .v19_0, let token {
             let authBody: JSON = .init(dictionaryLiteral: ("auth", token))
             let newBody: JSON
             if let httpBody = urlRequest.httpBody {

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -161,12 +161,8 @@ public class ApiClient {
     
     private func execute(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
         var urlRequest: URLRequest = urlRequest // make mutable
-        print("DEBUG executing \(urlRequest.httpMethod) | \(fetchedVersion) | \(token)...")
         
-        // add 0.18x "auth" param if on 18.x instance and token defined
-        // need to use fetched
-        // if version < .v19_0, let token, let httpBody = urlRequest.httpBody {
-        
+        // add 0.18x "auth" param if on 18.x (or unrecognized) instance and we have a token to send
         let apiVersionRecognized: Bool
         if case .other = fetchedVersion {
             apiVersionRecognized = false
@@ -180,18 +176,12 @@ public class ApiClient {
             let authBody: JSON = .init(dictionaryLiteral: ("auth", token))
             let newBody: JSON
             if let httpBody = urlRequest.httpBody {
-                print("DEBUG adding to \(httpBody)")
                 newBody = try JSON(httpBody).merged(with: authBody)
             } else {
-                print("DEBUG creating new body")
                 newBody = authBody
             }
             
-            print("DEBUG post-merge \(newBody)")
-            
             urlRequest.httpBody = try newBody.rawData()
-        } else {
-            print("DEBUG will not add to \(urlRequest.description)")
         }
         
         do {

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -162,7 +162,7 @@ public class ApiClient {
     private func execute(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
         var urlRequest: URLRequest = urlRequest // make mutable
         
-        // add 0.18x "auth" param if on 18.x (or unrecognized) instance and we have a token to send
+        // add 0.18x "auth" param if on 18.x (or unrecognized) instance
         let apiVersionRecognized: Bool
         if case .other = fetchedVersion {
             apiVersionRecognized = false
@@ -170,9 +170,9 @@ public class ApiClient {
             apiVersionRecognized = true
         }
 
-        if urlRequest.httpMethod != "GET",
+        if urlRequest.httpMethod != "GET", // GET requests do not support body
            !apiVersionRecognized || fetchedVersion ?? .v18_0 < .v19_0,
-           let token {
+           let token { // only add if we have a token
             let authBody: JSON = .init(dictionaryLiteral: ("auth", token))
             let newBody: JSON
             if let httpBody = urlRequest.httpBody {

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -161,7 +161,7 @@ public class ApiClient {
     
     private func execute(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
         var urlRequest: URLRequest = urlRequest // make mutable
-        print("DEBUG executing \(urlRequest.httpMethod)...")
+        print("DEBUG executing \(urlRequest.httpMethod) | \(fetchedVersion) | \(token)...")
         
         // add 0.18x "auth" param if on 18.x instance and token defined
         // need to use fetched

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -56,7 +56,7 @@ public class ApiClient {
     }
     
     /// Returns whether the version supports the given feature
-    func supports(_ feature: SiteVersion.Feature) async throws -> Bool {
+    public func supports(_ feature: SiteVersion.Feature) async throws -> Bool {
         try await version.suppports(feature)
     }
     

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -7,6 +7,7 @@
 
 import Combine
 import Foundation
+import SwiftyJSON
 
 @Observable
 public class ApiClient {
@@ -159,6 +160,14 @@ public class ApiClient {
     }
     
     private func execute(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
+        // add 0.18x "auth" param if on 18.x instance and token defined
+        if try await version < .v19_0, let token, let httpBody = urlRequest.httpBody {
+            var body = JSON(httpBody)
+            print("DEBUG \(body)")
+            body = try body.merged(with: JSON.init(dictionaryLiteral: ("auth", token)))
+            print("DEBUG post-merge \(body)")
+        }
+        
         do {
             return try await urlSession.data(for: urlRequest)
         } catch {

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -166,6 +166,8 @@ public class ApiClient {
             print("DEBUG \(body)")
             body = try body.merged(with: JSON.init(dictionaryLiteral: ("auth", token)))
             print("DEBUG post-merge \(body)")
+        } else {
+            print("DEBUG will not add to \(urlRequest.description)")
         }
         
         do {

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -131,7 +131,7 @@ public class ApiClient {
     func perform<Request: ApiRequest>(_ request: Request) async throws -> Request.Response {
         let urlRequest = try urlRequest(from: request)
         // this line intentionally left commented for convenient future debugging
-        // urlRequest.debug()
+        urlRequest.debug()
         let (data, response) = try await execute(urlRequest)
         if let response = response as? HTTPURLResponse {
             if response.statusCode >= 500 { // Error code for server being offline.
@@ -160,6 +160,7 @@ public class ApiClient {
     }
     
     private func execute(_ urlRequest: URLRequest) async throws -> (Data, URLResponse) {
+        print("DEBUG executing...")
         // add 0.18x "auth" param if on 18.x instance and token defined
         if try await version < .v19_0, let token, let httpBody = urlRequest.httpBody {
             var body = JSON(httpBody)

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -131,7 +131,7 @@ public class ApiClient {
     func perform<Request: ApiRequest>(_ request: Request) async throws -> Request.Response {
         let urlRequest = try urlRequest(from: request)
         // this line intentionally left commented for convenient future debugging
-        urlRequest.debug()
+        // urlRequest.debug()
         let (data, response) = try await execute(urlRequest)
         if let response = response as? HTTPURLResponse {
             if response.statusCode >= 500 { // Error code for server being offline.

--- a/Sources/MlemMiddleware/Content Models/Internal/SiteVersion.swift
+++ b/Sources/MlemMiddleware/Content Models/Internal/SiteVersion.swift
@@ -50,6 +50,27 @@ public enum SiteVersion: Equatable, Hashable {
     public static let v19_4: Self = .init("0.19.4")
 }
 
+public extension SiteVersion {
+    enum Feature {
+        case headerAuthentication, batchMarkRead
+        
+        var minimumVersion: SiteVersion {
+            switch self {
+            case .headerAuthentication: .v19_0
+            case .batchMarkRead: .v19_0
+            }
+        }
+    }
+    
+    /// Checks whether this SiteVersion supports the given feature. Always returns false if version unknown.
+    func suppports(_ feature: Feature) -> Bool {
+        switch self {
+        case .other: false
+        default: feature.minimumVersion <= self
+        }
+    }
+}
+
 extension SiteVersion: CustomStringConvertible {
     public var description: String {
         switch self {


### PR DESCRIPTION
Adds logic to include the "auth" body param when submitting requests to instances running < 0.19.

The `eric/beehaw-compatibility` branch on Mlem is hooked up to this branch for testing.