### PR TITLE
Post3

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+Caches.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Caches.swift
@@ -36,6 +36,7 @@ extension ApiClient {
         
         var post1: Post1Cache = .init()
         var post2: Post2Cache = .init()
+        var post3: Post3Cache = .init()
         
         var comment1: Comment1Cache = .init()
         var comment2: Comment2Cache = .init()
@@ -58,6 +59,7 @@ extension ApiClient {
             person4.clean()
             post1.clean()
             post2.clean()
+            post3.clean()
             comment1.clean()
             comment2.clean()
             reply1.clean()

--- a/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -88,10 +88,10 @@ public extension ApiClient {
         )
     }
         
-    func getPost(id: Int) async throws -> Post2 {
+    func getPost(id: Int) async throws -> Post3 {
         let request = GetPostRequest(id: id, commentId: nil)
         let response = try await perform(request)
-        return caches.post2.getModel(api: self, from: response.postView)
+        return caches.post3.getModel(api: self, from: response)
     }
     
     func getPost(actorId: URL) async throws -> Post2 {

--- a/Sources/MlemMiddleware/API Client/Caching/Caches/PostCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/PostCaches.swift
@@ -61,3 +61,19 @@ class Post2Cache: ApiTypeBackedCache<Post2, ApiPostView> {
         item.update(with: apiType, semaphore: semaphore)
     }
 }
+
+class Post3Cache: ApiTypeBackedCache<Post3, ApiGetPostResponse> {
+    override func performModelTranslation(api: ApiClient, from apiType: ApiGetPostResponse) -> Post3 {
+        .init(
+            api: api,
+            post2: api.caches.post2.getModel(api: api, from: apiType.postView),
+            community: api.caches.community2.getModel(api: api, from: apiType.communityView),
+            communityModerators: apiType.moderators.map { api.caches.person1.getModel(api: api, from: $0.moderator) },
+            crossPosts: apiType.crossPosts.map { api.caches.post2.getModel(api: api, from: $0) }
+        )
+    }
+    
+    override func updateModel(_ item: Post3, with apiType: ApiGetPostResponse, semaphore: UInt? = nil) {
+        item.update(with: apiType, semaphore: semaphore)
+    }
+}

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Post+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Post+CacheExtensions.swift
@@ -53,3 +53,20 @@ extension Post2: CacheIdentifiable {
         community.update(with: post.community, semaphore: semaphore)
     }
 }
+
+extension Post3: CacheIdentifiable {
+    public var cacheId: Int { id }
+    
+    func update(with post: ApiGetPostResponse, semaphore: UInt? = nil) {
+        setIfChanged(\.communityModerators, post.moderators.map { moderatorView in
+            api.caches.person1.performModelTranslation(api: api, from: moderatorView.moderator)
+        })
+        
+        setIfChanged(\.crossPosts, post.crossPosts.map { crossPost in
+            api.caches.post2.performModelTranslation(api: api, from: crossPost)
+        })
+        
+        post2.update(with: post.postView, semaphore: semaphore)
+        community.update(with: post.communityView, semaphore: semaphore)
+    }
+}

--- a/Sources/MlemMiddleware/Content Models/Comment/Comment1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Comment/Comment1Providing.swift
@@ -111,7 +111,7 @@ public extension Comment1Providing {
             return comments
         }
         
-        return comments.filter { $0.parentCommentIds.contains(id) || parentCommentIds.contains($0.id) || $0 === self }
+        return comments.filter { $0.parentCommentIds.contains(id) || self.parentCommentIds.contains($0.id) || $0.id == self.id }
     }
     
     func reply(content: String, languageId: Int? = nil) async throws -> Comment2 {

--- a/Sources/MlemMiddleware/Content Models/Comment/Comment2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Comment/Comment2Providing.swift
@@ -10,9 +10,9 @@ import Foundation
 public protocol Comment2Providing: Comment1Providing, Interactable2Providing, PersonContentProviding {
     var comment2: Comment2 { get }
     
-    var creator: Person1 { get }
+    var creator: any Person { get }
     var post: Post1 { get }
-    var community: Community1 { get }
+    var community: any Community { get }
     var creatorIsModerator: Bool? { get }
     var creatorIsAdmin: Bool? { get }
     var bannedFromCommunity: Bool? { get }
@@ -21,9 +21,9 @@ public protocol Comment2Providing: Comment1Providing, Interactable2Providing, Pe
 public extension Comment2Providing {
     var comment1: Comment1 { comment2.comment1 }
     
-    var creator: Person1 { comment2.creator }
+    var creator: any Person { comment2.creator }
     var post: Post1 { comment2.post }
-    var community: Community1 { comment2.community }
+    var community: any Community { comment2.community }
     var votes: VotesModel { comment2.votes }
     var saved: Bool { comment2.saved }
     var creatorIsModerator: Bool? { comment2.creatorIsModerator }
@@ -31,7 +31,7 @@ public extension Comment2Providing {
     var bannedFromCommunity: Bool? { comment2.bannedFromCommunity }
     var commentCount: Int { comment2.commentCount }
     
-    var creator_: Person1? { comment2.creator }
+    var creator_: (any Person)? { comment2.creator }
     var post_: Post1? { comment2.post }
     var community_: Community1? { comment2.community }
     var votes_: VotesModel? { comment2.votes }

--- a/Sources/MlemMiddleware/Content Models/Comment/CommentStubProviding.swift
+++ b/Sources/MlemMiddleware/Content Models/Comment/CommentStubProviding.swift
@@ -22,9 +22,9 @@ public protocol CommentStubProviding: ActorIdentifiable, ContentModel {
     var languageId_: Int? { get }
     
     // From Comment2Providing. These are defined as nil in the extension below
-    var creator_: Person1? { get }
+    var creator_: (any Person)? { get }
     var post_: Post1? { get }
-    var community_: Community1? { get }
+    var community_: (any Community)? { get }
     var votes_: VotesModel? { get }
     var saved_: Bool? { get }
     var creatorIsModerator_: Bool? { get }
@@ -47,9 +47,9 @@ public extension CommentStubProviding {
     var removed_: Bool? { nil }
     var languageId_: Int? { nil }
     
-    var creator_: Person1? { nil }
+    var creator_: (any Person)? { nil }
     var post_: Post1? { nil }
-    var community_: Community1? { nil }
+    var community_: (any Community)? { nil }
     var votes_: VotesModel? { nil }
     var saved_: Bool? { nil }
     var creatorIsModerator_: Bool? { nil }

--- a/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Interactable/Interactable1Providing.swift
@@ -12,7 +12,7 @@ public protocol Interactable1Providing: AnyObject, ContentModel, ReportableProvi
     var created: Date { get }
     var updated: Date? { get }
     
-    var creator_: Person1? { get }
+    var creator_: (any Person)? { get }
     var creatorIsModerator_: Bool? { get }
     var creatorIsAdmin_: Bool? { get }
     var bannedFromCommunity_: Bool? { get }

--- a/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
@@ -9,8 +9,8 @@ import Foundation
 
 // Content that can be upvoted, downvoted, saved etc
 public protocol Interactable2Providing: Interactable1Providing {
-    var creator: Person1 { get }
-    var community: Community1 { get }
+    var creator: any Person { get }
+    var community: any Community { get }
     var creatorIsModerator: Bool? { get }
     var creatorIsAdmin: Bool? { get }
     var bannedFromCommunity: Bool? { get }

--- a/Sources/MlemMiddleware/Content Models/Post/AnyPost.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/AnyPost.swift
@@ -11,7 +11,7 @@ import Foundation
 public class AnyPost: Hashable, Upgradable {
     public typealias Base = PostStubProviding
     public typealias MinimumRenderable = Post1Providing
-    public typealias Upgraded = Post2Providing
+    public typealias Upgraded = Post3Providing
     
     public var wrappedValue: any PostStubProviding
     

--- a/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post2Providing.swift
@@ -11,8 +11,8 @@ import Nuke
 public protocol Post2Providing: Post1Providing, Interactable2Providing, PersonContentProviding {
     var post2: Post2 { get }
     
-    var creator: Person1 { get }
-    var community: Community1 { get }
+    var creator: any Person { get }
+    var community: any Community { get }
     var unreadCommentCount: Int { get }
     var read: Bool { get }
     var hidden: Bool { get }
@@ -21,8 +21,8 @@ public protocol Post2Providing: Post1Providing, Interactable2Providing, PersonCo
 public extension Post2Providing {
     var post1: Post1 { post2.post1 }
     
-    var creator: Person1 { post2.creator }
-    var community: Community1 { post2.community }
+    var creator: any Person { post2.creator }
+    var community: any Community { post2.community }
     var creatorIsModerator: Bool? { post2.creatorIsModerator }
     var creatorIsAdmin: Bool? { post2.creatorIsAdmin }
     var bannedFromCommunity: Bool? { post2.bannedFromCommunity }
@@ -33,8 +33,8 @@ public extension Post2Providing {
     var read: Bool { post2.read }
     var hidden: Bool { post2.hidden }
     
-    var creator_: Person1? { post2.creator }
-    var community_: Community1? { post2.community }
+    var creator_: (any Person)? { post2.creator }
+    var community_: (any Community)? { post2.community }
     var creatorIsModerator_: Bool? { post2.creatorIsModerator }
     var creatorIsAdmin_: Bool? { post2.creatorIsAdmin }
     var bannedFromCommunity_: Bool? { post2.bannedFromCommunity }
@@ -51,9 +51,7 @@ public extension Post2Providing {
     private var readManager: StateManager<Bool> { post2.readManager }
     private var savedManager: StateManager<Bool> { post2.savedManager }
     private var hiddenManager: StateManager<Bool> { post2.hiddenManager }
-    
-    func upgrade() async throws -> any Post { self }
-    
+        
     @discardableResult
     func updateRead(_ newValue: Bool, shouldQueue: Bool = false) -> Task<StateUpdateResult, Never> {
         if shouldQueue {

--- a/Sources/MlemMiddleware/Content Models/Post/Post3.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post3.swift
@@ -1,0 +1,35 @@
+//
+//  Post3.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 25/09/2024.
+//
+
+import Observation
+
+@Observable
+public final class Post3: Post3Providing {
+    public static let tierNumber: Int = 3
+    public var api: ApiClient
+    public var post3: Post3 { self }
+    
+    public let post2: Post2
+    public let community: Community2
+    public var communityModerators: [Person1]
+    public var crossPosts: [Post2]
+    
+    internal init(
+        api: ApiClient,
+        post2: Post2,
+        community: Community2,
+        communityModerators: [Person1],
+        crossPosts: [Post2]
+    ) {
+        self.api = api
+        self.post2 = post2
+        self.community = community
+        self.communityModerators = communityModerators
+        self.crossPosts = crossPosts
+    }
+}
+

--- a/Sources/MlemMiddleware/Content Models/Post/Post3Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post3Providing.swift
@@ -1,0 +1,29 @@
+//
+//  Post3Providing.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 25/09/2024.
+//
+
+import Foundation
+
+public protocol Post3Providing: Post2Providing {
+    var post3: Post3 { get }
+    
+    var communityModerators: [Person1] { get }
+    var crossPosts: [Post2] { get }
+}
+
+public extension Post3Providing {
+    func upgrade() async throws -> any Post { self }
+
+    // Override `Post2Providing` definition
+    var community: any Community { post3.community }
+    var community_: (any Community)? { post3.community }
+    
+    var communityModerators: [Person1] { post3.communityModerators }
+    var crossPosts: [Post2] { post3.crossPosts }
+    
+    var communityModerators_: [Person1]? { post3.communityModerators }
+    var crossPosts_: [Post2]? { post3.crossPosts }
+}

--- a/Sources/MlemMiddleware/Content Models/Post/PostStubProviding.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/PostStubProviding.swift
@@ -29,8 +29,8 @@ public protocol PostStubProviding: ActorIdentifiable, ContentModel {
     var altText_: String? { get }
     
     // From Post2Providing. These are defined as nil in the extension below
-    var creator_: Person1? { get }
-    var community_: Community1? { get }
+    var creator_: (any Person)? { get }
+    var community_: (any Community)? { get }
     var creatorIsModerator_: Bool? { get }
     var creatorIsAdmin_: Bool? { get }
     var bannedFromCommunity_: Bool? { get }
@@ -40,6 +40,10 @@ public protocol PostStubProviding: ActorIdentifiable, ContentModel {
     var saved_: Bool? { get }
     var read_: Bool? { get }
     var hidden_: Bool? { get }
+    
+    // From Post3Providing. These are defined as nil in the extension below
+    var communityModerators_: [Person1]? { get }
+    var crossPosts_: [Post2]? { get }
     
     func upgrade() async throws -> any Post
 }
@@ -64,8 +68,8 @@ public extension PostStubProviding {
     var languageId_: Int? { nil }
     var altText_: String? { nil }
     
-    var creator_: Person1? { nil }
-    var community_: Community1? { nil }
+    var creator_: (any Person)? { nil }
+    var community_: (any Community)? { nil }
     var creatorIsModerator_: Bool? { nil }
     var creatorIsAdmin_: Bool? { nil }
     var bannedFromCommunity_: Bool? { nil }
@@ -75,6 +79,9 @@ public extension PostStubProviding {
     var saved_: Bool? { nil }
     var read_: Bool? { nil }
     var hidden_: Bool? { nil }
+    
+    var communityModerators_: [Person1]? { nil }
+    var crossPosts_: [Post2]? { nil }
 }
 
 public extension PostStubProviding {

--- a/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Reply/Reply1Providing.swift
@@ -32,9 +32,9 @@ public protocol Reply1Providing:
     
     // From Reply2Providing
     var comment_: Comment1? { get }
-    var creator_: Person1? { get }
+    var creator_: (any Person)? { get }
     var post_: Post1? { get }
-    var community_: Community1? { get }
+    var community_: (any Community)? { get }
     var recipient_: Person1? { get }
     var subscribed_: Bool? { get }
     var commentCount_: Int? { get }
@@ -71,9 +71,9 @@ public extension Reply1Providing {
     
     // From Reply2Providing
     var comment_: Comment1? { nil }
-    var creator_: Person1? { nil }
+    var creator_: (any Person)? { nil }
     var post_: Post1? { nil }
-    var community_: Community1? { nil }
+    var community_: (any Community)? { nil }
     var recipient_: Person1? { nil }
     var subscribed_: Bool? { nil }
     var commentCount_: Int? { nil }

--- a/Sources/MlemMiddleware/Content Models/Reply/Reply2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Reply/Reply2Providing.swift
@@ -12,9 +12,9 @@ public protocol Reply2Providing: Reply1Providing, Interactable2Providing {
     
     var reply1: Reply1 { get }
     var comment: Comment1 { get }
-    var creator: Person1 { get }
+    var creator: any Person { get }
     var post: Post1 { get }
-    var community: Community1 { get }
+    var community: any Community { get }
     var recipient: Person1 { get }
     var subscribed: Bool { get }
     var commentCount: Int { get }
@@ -26,9 +26,9 @@ public protocol Reply2Providing: Reply1Providing, Interactable2Providing {
 public extension Reply2Providing {
     var reply1: Reply1 { reply2.reply1 }
     var comment: Comment1 { reply2.comment }
-    var creator: Person1 { reply2.creator }
+    var creator: any Person { reply2.creator }
     var post: Post1 { reply2.post }
-    var community: Community1 { reply2.community }
+    var community: any Community { reply2.community }
     var recipient: Person1 { reply2.recipient }
     var subscribed: Bool { reply2.subscribed }
     var commentCount: Int { reply2.commentCount }
@@ -38,9 +38,9 @@ public extension Reply2Providing {
     
     var reply1_: Reply1? { reply2.reply1 }
     var comment_: Comment1? { reply2.comment }
-    var creator_: Person1? { reply2.creator }
+    var creator_: (any Person)? { reply2.creator }
     var post_: Post1? { reply2.post }
-    var community_: Community1? { reply2.community }
+    var community_: (any Community)? { reply2.community }
     var recipient_: Person1? { reply2.recipient }
     var subscribed_: Bool? { reply2.subscribed }
     var commentCount_: Int? { reply2.commentCount }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetPostResponse+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/ApiGetPostResponse+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  ApiGetPostResponse+Extensions.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 25/09/2024.
+//
+
+import Foundation
+
+extension ApiGetPostResponse: ActorIdentifiable, CacheIdentifiable, Identifiable {
+    public var cacheId: Int { id }
+
+    public var actorId: URL { postView.post.apId }
+    public var id: Int { postView.post.id }
+}


### PR DESCRIPTION
Adds `Post3`. `Post3` contains a `Community2`, which supersedes the `Community1` provided by `Post2`. To support this the type of `Post2Providing.community` and related properties needed to be changed from `Community1` to `any Community`.