### PR TITLE
Actor Feed Loaders

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,32 @@
+{
+  "pins" : [
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "8e431251dea0081b6ab154dab61a6ec74e4b6577",
+        "version" : "12.6.0"
+      }
+    },
+    {
+      "identity" : "semaphore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/Semaphore.git",
+      "state" : {
+        "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
+        "version" : "0.0.8"
+      }
+    },
+    {
+      "identity" : "swiftyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftyJSON/SwiftyJSON.git",
+      "state" : {
+        "revision" : "2b6054efa051565954e1d2b9da831680026cd768",
+        "version" : "4.3.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Sources/MlemMiddleware/Constants/MiddlewareConstants.swift
+++ b/Sources/MlemMiddleware/Constants/MiddlewareConstants.swift
@@ -9,4 +9,5 @@ import Foundation
 
 enum MiddlewareConstants {
     static let infiniteLoadThresholdOffset: Int = 10
+    static let maxRetries: Int = 3
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
@@ -7,9 +7,7 @@
 
 import Foundation
 
-class CommunityFetcher: Fetcher {
-    typealias Item = Community2
-    
+class CommunityFetcher: Fetcher<Community2> {
     let api: ApiClient
     var query: String
     var pageSize: Int
@@ -24,7 +22,7 @@ class CommunityFetcher: Fetcher {
         self.sort = sort
     }
     
-    func fetchPage(_ page: Int) async throws -> FetchResponse<Community2> {
+    override func fetchPage(_ page: Int) async throws -> FetchResponse<Community2> {
         let communities = try await api.searchCommunities(
             query: query,
             page: page,
@@ -40,9 +38,9 @@ class CommunityFetcher: Fetcher {
         )
     }
     
-    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Community2> {
-        fatalError("Unsupported loading operation")
-    }
+//    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Community2> {
+//        fatalError("Unsupported loading operation")
+//    }
 }
 
 @Observable

--- a/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
@@ -10,19 +10,19 @@ import Foundation
 class CommunityFetcher: Fetcher<Community2> {
     let api: ApiClient
     var query: String
-    var pageSize: Int
     var listing: ApiListingType
     var sort: ApiSortType
     
     init(api: ApiClient, query: String, pageSize: Int, listing: ApiListingType, sort: ApiSortType) {
         self.api = api
         self.query = query
-        self.pageSize = pageSize
         self.listing = listing
         self.sort = sort
+        
+        super.init(pageSize: pageSize)
     }
     
-    override func fetchPage(_ page: Int) async throws -> FetchResponse<Community2> {
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
         let communities = try await api.searchCommunities(
             query: query,
             page: page,
@@ -31,16 +31,12 @@ class CommunityFetcher: Fetcher<Community2> {
             sort: sort
         )
         
-        return FetchResponse<Community2>.init(
+        return .init(
             items: communities,
             prevCursor: nil,
             nextCursor: nil
         )
     }
-    
-//    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Community2> {
-//        fatalError("Unsupported loading operation")
-//    }
 }
 
 @Observable

--- a/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
@@ -48,9 +48,6 @@ class CommunityFetchProvider: FetchProviding {
 @Observable
 public class CommunityFeedLoader: StandardFeedLoader<Community2> {
     public var api: ApiClient
-//    public private(set) var query: String
-//    public private(set) var listing: ApiListingType
-//    public private(set) var sort: ApiSortType
     
     public init(
         api: ApiClient,
@@ -60,10 +57,7 @@ public class CommunityFeedLoader: StandardFeedLoader<Community2> {
         sort: ApiSortType = .topAll
     ) {
         self.api = api
-//        self.query = query
-//        self.listing = listing
-//        self.sort = sort
-        
+
         super.init(
             filter: .init(),
             fetchProvider: CommunityFetchProvider(

--- a/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
@@ -28,8 +28,7 @@ struct CommunityFetchProvider: FetchProviding {
         return FetchResponse<Community2>.init(
             items: communities,
             prevCursor: nil,
-            nextCursor: nil,
-            numFiltered: 0
+            nextCursor: nil
         )
     }
     
@@ -83,14 +82,9 @@ public class CommunityFeedLoader: StandardFeedLoader<Community2> {
         return FetchResponse<Community2>.init(
             items: communities,
             prevCursor: nil,
-            nextCursor: nil,
-            numFiltered: 0
+            nextCursor: nil
         )
     }
-    
-//    override public func refresh(clearBeforeRefresh: Bool) async throws {
-//        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
-//    }
     
     public func refresh(
         query: String? = nil,

--- a/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
@@ -49,6 +49,9 @@ class CommunityFetcher: Fetcher {
 public class CommunityFeedLoader: StandardFeedLoader<Community2> {
     public var api: ApiClient
     
+    // force unwrap because this should ALWAYS be a CommunityFetcher
+    var communityFetcher: CommunityFetcher { fetcher as! CommunityFetcher }
+    
     public init(
         api: ApiClient,
         query: String = "",
@@ -75,11 +78,6 @@ public class CommunityFeedLoader: StandardFeedLoader<Community2> {
         sort: ApiSortType? = nil,
         clearBeforeRefresh: Bool = false
     ) async throws {
-        guard let communityFetcher = fetcher as? CommunityFetcher else {
-            assertionFailure("fetcher is not CommunityFetcher")
-            return
-        }
-        
         communityFetcher.query = query ?? communityFetcher.query
         communityFetcher.listing = listing ?? communityFetcher.listing
         communityFetcher.sort = sort ?? communityFetcher.sort

--- a/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Community/CommunityFeedLoader.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class CommunityFetchProvider: FetchProviding {
+class CommunityFetcher: Fetcher {
     typealias Item = Community2
     
     let api: ApiClient
@@ -60,7 +60,7 @@ public class CommunityFeedLoader: StandardFeedLoader<Community2> {
 
         super.init(
             filter: .init(),
-            fetchProvider: CommunityFetchProvider(
+            fetcher: CommunityFetcher(
                 api: api,
                 query: query,
                 pageSize: pageSize,
@@ -75,14 +75,14 @@ public class CommunityFeedLoader: StandardFeedLoader<Community2> {
         sort: ApiSortType? = nil,
         clearBeforeRefresh: Bool = false
     ) async throws {
-        guard let communityFetchProvider = fetchProvider as? CommunityFetchProvider else {
-            assertionFailure("fetchProvider is not CommunityFetchProvider")
+        guard let communityFetcher = fetcher as? CommunityFetcher else {
+            assertionFailure("fetcher is not CommunityFetcher")
             return
         }
         
-        communityFetchProvider.query = query ?? communityFetchProvider.query
-        communityFetchProvider.listing = listing ?? communityFetchProvider.listing
-        communityFetchProvider.sort = sort ?? communityFetchProvider.sort
+        communityFetcher.query = query ?? communityFetcher.query
+        communityFetcher.listing = listing ?? communityFetcher.listing
+        communityFetcher.sort = sort ?? communityFetcher.sort
         try await refresh(clearBeforeRefresh: clearBeforeRefresh)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/CoreFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/CoreFeedLoader.swift
@@ -12,7 +12,7 @@ import Observation
 @Observable
 public class CoreFeedLoader<Item: FeedLoadable>: FeedLoading {
     private(set) public var items: [Item] = .init()
-    private(set) public var loadingState: LoadingState = .idle
+    private(set) public var loadingState: LoadingState = .loading
     
     private(set) var thresholds: Thresholds<Item> = .init()
     
@@ -38,6 +38,7 @@ public class CoreFeedLoader<Item: FeedLoadable>: FeedLoading {
     /// Updates the loading state
     @MainActor
     func setLoading(_ newState: LoadingState) {
+        // print("DEBUG \(newState)")
         loadingState = newState
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/CoreFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/CoreFeedLoader.swift
@@ -16,12 +16,6 @@ public class CoreFeedLoader<Item: FeedLoadable>: FeedLoading {
     
     private(set) var thresholds: Thresholds<Item> = .init()
     
-    private(set) var pageSize: Int
-
-    init(pageSize: Int) {
-        self.pageSize = pageSize
-    }
-    
     /// If the given item is the loading threshold item, loads more content
     /// This should be called as an .onAppear of every item in a feed that should support infinite scrolling
     public func loadIfThreshold(_ item: Item) throws {

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/CoreFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/CoreFeedLoader.swift
@@ -38,7 +38,6 @@ public class CoreFeedLoader<Item: FeedLoadable>: FeedLoading {
     /// Updates the loading state
     @MainActor
     func setLoading(_ newState: LoadingState) {
-        // print("DEBUG \(newState)")
         loadingState = newState
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/CoreFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/CoreFeedLoader.swift
@@ -12,7 +12,7 @@ import Observation
 @Observable
 public class CoreFeedLoader<Item: FeedLoadable>: FeedLoading {
     private(set) public var items: [Item] = .init()
-    private(set) public var loadingState: LoadingState = .loading
+    internal(set) public var loadingState: LoadingState = .loading
     
     private(set) var thresholds: Thresholds<Item> = .init()
     

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoaderSort.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoaderSort.swift
@@ -12,6 +12,13 @@ public enum FeedLoaderSort: Comparable {
     public enum SortType {
         case new
     }
+    
+    var description: String {
+        switch self {
+        case let .new(date):
+            "NEW (\(date))"
+        }
+    }
 }
 
 public extension FeedLoaderSort {

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoaderSort.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/FeedLoaderSort.swift
@@ -12,13 +12,6 @@ public enum FeedLoaderSort: Comparable {
     public enum SortType {
         case new
     }
-    
-    var description: String {
-        switch self {
-        case let .new(date):
-            "NEW (\(date))"
-        }
-    }
 }
 
 public extension FeedLoaderSort {

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -78,7 +78,7 @@ public class Fetcher<Item: FeedLoadable> {
                 // if nothing returned, loading is finished
                 if response.items.count < pageSize {
                     print("[\(Item.self) Fetcher] received undersized page (\(response.items.count)/\(pageSize))")
-                    return .done(.init())
+                    return .done(response.items)
                 }
                 self.cursor = response.nextCursor
                 return .success(response.items)

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -35,15 +35,17 @@ enum LoadingResponse<Item: FeedLoadable> {
 }
 
 public class Fetcher<Item: FeedLoadable> {
+    var pageSize: Int
     var page: Int
     private var cursor: String?
     
-    init (page: Int = 0) {
+    init (pageSize: Int, page: Int = 0) {
+        self.pageSize = pageSize
         self.page = page
     }
     
     /// Helper struct bundling the response from a fetchPage or fetchCursor call
-    struct FetchResponse<Item: FeedLoadable> {
+    struct FetchResponse {
         /// Items returned
         public let items: [Item]
         
@@ -89,7 +91,7 @@ public class Fetcher<Item: FeedLoadable> {
     /// - Parameters:
     ///   - page: page number to fetch
     /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
-    func fetchPage(_ page: Int) async throws -> FetchResponse<Item> {
+    func fetchPage(_ page: Int) async throws -> FetchResponse {
         preconditionFailure("This method must be implemented by the inheriting class")
     }
     
@@ -97,7 +99,7 @@ public class Fetcher<Item: FeedLoadable> {
     /// - Parameters:
     ///   - cursor: cursor to fetch
     /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
-    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Item> {
+    func fetchCursor(_ cursor: String) async throws -> FetchResponse {
         preconditionFailure("This method must be implemented by the inheriting class")
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -76,7 +76,8 @@ public class Fetcher<Item: FeedLoadable> {
                 let response = try await fetchPage(page)
                 
                 // if nothing returned, loading is finished
-                if response.items.isEmpty {
+                if response.items.count < pageSize {
+                    print("[\(Item.self) Fetcher] received undersized page (\(response.items.count)/\(pageSize))")
                     return .done(.init())
                 }
                 self.cursor = response.nextCursor

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -1,0 +1,118 @@
+//
+//  LoadingActor.swift
+//  MlemMiddleware
+//
+//  Created by Eric Andrews on 2024-10-27.
+//
+
+import Foundation
+
+/// Helper struct bundling the response from a fetchPage or fetchCursor call
+public struct FetchResponse<Item: FeedLoadable> {
+    /// Items returned
+    public let items: [Item]
+    
+    /// Cursor used to fetch this response, if applicable
+    public let prevCursor: String?
+    
+    /// New cursor, if applicable
+    public let nextCursor: String?
+    
+    /// Number of items filtered out
+    public let numFiltered: Int
+    
+    /// True if the response has content, false otherwise. It is possible for a filter to remove all fetched items; this avoids that triggering an erroneous end of feed.
+    public var hasContent: Bool {
+        (prevCursor == nil || nextCursor != prevCursor) && // if cursor used to fetch, ensure same cursor not returned
+        items.count + numFiltered > 0 // total sum of fetched items non-zero
+    }
+}
+
+enum LoadingResponse<Item: FeedLoadable> {
+    enum FailureReason: String {
+        case error, cancelled, ignored
+    }
+    
+    case success(FetchResponse<Item>)
+    case failure(FailureReason)
+}
+
+protocol FetchProviding<Item> {
+    associatedtype Item: FeedLoadable
+    
+    /// Fetches the given page of items. This method must be supplied by the parent FeedLoader because different items are loaded differently. The parent FeedLoader is responsible for handling fetch parameters (e.g., page size, unread only) and performing filtering
+    /// - Parameters:
+    ///   - page: page number to fetch
+    /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
+    func fetchPage(_ page: Int) async throws -> FetchResponse<Item>
+    
+    /// Fetches items from the given cursor. This method must be supplied by the parent FeedLoader because different items are loaded differently. The parent FeedLoader is responsible for handling fetch parameters (e.g., page size, unread only) and performing filtering
+    /// - Parameters:
+    ///   - cursor: cursor to fetch
+    /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
+    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Item>
+}
+
+actor LoadingActor<Item: FeedLoadable> {
+    private var page: Int = 0
+    private var cursor: String?
+    private var loadingTask: Task<LoadingResponse<Item>, Error>?
+  
+    private var fetchProvider: any FetchProviding<Item>
+    
+    public init(fetchProvider: any FetchProviding<Item>) {
+        self.fetchProvider = fetchProvider
+    }
+    
+    /// Resets the loading actor and updates the fetching behavior to use the provided callbacks
+    func updateFetching(fetchProvider: any FetchProviding<Item>) {
+        reset()
+        self.fetchProvider = fetchProvider
+    }
+    
+    /// Cancels any ongoing loading and resets the page/cursor to 0
+    func reset() {
+        loadingTask?.cancel()
+        page = 0
+        cursor = nil
+    }
+    
+    /// Resets this LoadingActor, then loads the first page of items
+    func refresh() async -> LoadingResponse<Item> {
+        reset()
+        return await load()
+    }
+    
+    /// Loads the next page of items.
+    /// - Returns: on success, .success with FetchResponse containing loaded items; if another load is underway, .ignored; if the load is cancelled, .cancelled
+    func load() async -> LoadingResponse<Item> {
+        guard loadingTask == nil else {
+            print("DEBUG [\(Item.self) loader] ignoring request, load underway")
+            return .failure(.ignored)
+        }
+        
+        loadingTask = Task<LoadingResponse<Item>, Error> {
+            do {
+                if let cursor, page > 0 {
+                    return .success(try await fetchProvider.fetchCursor(cursor))
+                } else {
+                    page += 1
+                    return .success(try await fetchProvider.fetchPage(page))
+                }
+            } catch is CancellationError {
+                return .failure(.cancelled)
+            }
+        }
+        
+        do {
+            guard let loadingTask else {
+                assertionFailure("loadingTask is nil!")
+                return .failure(.error)
+            }
+            return try await loadingTask.result.get()
+        } catch {
+            print(error)
+            return .failure(.error)
+        }
+    }
+}

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -101,7 +101,7 @@ public class Fetcher<Item: FeedLoadable> {
         preconditionFailure("This method must be implemented by the inheriting class")
     }
     
-    /// Resets the fetcher
+    /// Resets the fetcher's page and cursor tracking. This method should only be overridden to handle abnormal pagination behavior (e.g., PersonContentFetcher); it should NOT change loading parameters such as query or sort.
     func reset() {
         page = 0
         cursor = nil

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -85,12 +85,6 @@ actor LoadingActor<Item: FeedLoadable> {
         cursor = nil
     }
     
-    /// Resets this LoadingActor, then loads the first page of items
-//    func refresh() async -> LoadingResponse<Item> {
-//        reset()
-//        return await load()
-//    }
-    
     /// Loads the next page of items.
     /// - Returns: on success, .success with FetchResponse containing loaded items; if another load is underway, .ignored; if the load is cancelled, .cancelled
     func load() async -> LoadingResponse<Item> {

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -74,12 +74,6 @@ actor LoadingActor<Item: FeedLoadable> {
         self.fetcher = fetcher
     }
     
-    /// Resets the loading actor and updates the fetching behavior to use the provided callbacks
-    func updateFetching(fetcher: any Fetcher<Item>) {
-        reset()
-        self.fetcher = fetcher
-    }
-    
     /// Cancels any ongoing loading and resets the page/cursor to 0
     func reset() {
         loadingTask?.cancel()
@@ -127,7 +121,7 @@ actor LoadingActor<Item: FeedLoadable> {
                     
                     // if nothing returned, loading is finished
                     if response.items.isEmpty {
-                        done = true
+                        self.done = true
                         return .done(.init())
                     }
                     self.cursor = response.nextCursor

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -154,7 +154,7 @@ actor LoadingActor<Item: FeedLoadable> {
             }
             let result = try await loadingTask.result.get()
             
-            if case let .done = result {
+            if case .done = result {
                 self.done = true
             }
             

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -49,13 +49,13 @@ enum LoadingResponse<Item: FeedLoadable> {
 protocol Fetcher<Item> {
     associatedtype Item: FeedLoadable
     
-    /// Fetches the given page of items. This method must be supplied by the parent FeedLoader because different items are loaded differently. The parent FeedLoader is responsible for handling fetch parameters (e.g., page size, unread only) and performing filtering
+    /// Fetches the given page of items.
     /// - Parameters:
     ///   - page: page number to fetch
     /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
     func fetchPage(_ page: Int) async throws -> FetchResponse<Item>
     
-    /// Fetches items from the given cursor. This method must be supplied by the parent FeedLoader because different items are loaded differently. The parent FeedLoader is responsible for handling fetch parameters (e.g., page size, unread only) and performing filtering
+    /// Fetches items from the given cursor.
     /// - Parameters:
     ///   - cursor: cursor to fetch
     /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -63,15 +63,16 @@ protocol Fetcher<Item> {
 }
 
 actor LoadingActor<Item: FeedLoadable> {
-    private var page: Int = 0
+    private var page: Int
     private var cursor: String?
     private var loadingTask: Task<LoadingResponse<Item>, Error>?
     private var done: Bool = false
   
     private var fetcher: any Fetcher<Item>
     
-    public init(fetcher: any Fetcher<Item>) {
+    public init(fetcher: any Fetcher<Item>, page: Int = 0) {
         self.fetcher = fetcher
+        self.page = page
     }
     
     /// Cancels any ongoing loading and resets the page/cursor to 0

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -18,14 +18,14 @@ public struct FetchResponse<Item: FeedLoadable> {
     /// New cursor, if applicable
     public let nextCursor: String?
     
-    /// Number of items filtered out
-    public let numFiltered: Int
-    
-    /// True if the response has content, false otherwise. It is possible for a filter to remove all fetched items; this avoids that triggering an erroneous end of feed.
-    public var hasContent: Bool {
-        (prevCursor == nil || nextCursor != prevCursor) && // if cursor used to fetch, ensure same cursor not returned
-        items.count + numFiltered > 0 // total sum of fetched items non-zero
-    }
+//    /// Number of items filtered out
+//    public let numFiltered: Int
+//    
+//    /// True if the response has content, false otherwise. It is possible for a filter to remove all fetched items; this avoids that triggering an erroneous end of feed.
+//    public var hasContent: Bool {
+//        (prevCursor == nil || nextCursor != prevCursor) && // if cursor used to fetch, ensure same cursor not returned
+//        items.count + numFiltered > 0 // total sum of fetched items non-zero
+//    }
 }
 
 enum LoadingResponse<Item: FeedLoadable> {
@@ -33,7 +33,13 @@ enum LoadingResponse<Item: FeedLoadable> {
         case error, cancelled, ignored
     }
     
-    case success(FetchResponse<Item>)
+    /// Indicates a successful load with more items available to fetch
+    case success([Item])
+    
+    /// Indicates a successful load with no more items available to fetch
+    case done([Item])
+    
+    /// Indicates an unsuccessful load
     case failure(FailureReason)
 }
 
@@ -57,6 +63,7 @@ actor LoadingActor<Item: FeedLoadable> {
     private var page: Int = 0
     private var cursor: String?
     private var loadingTask: Task<LoadingResponse<Item>, Error>?
+    private var done: Bool = false
   
     private var fetchProvider: any FetchProviding<Item>
     
@@ -73,31 +80,60 @@ actor LoadingActor<Item: FeedLoadable> {
     /// Cancels any ongoing loading and resets the page/cursor to 0
     func reset() {
         loadingTask?.cancel()
+        done = false
         page = 0
         cursor = nil
     }
     
     /// Resets this LoadingActor, then loads the first page of items
-    func refresh() async -> LoadingResponse<Item> {
-        reset()
-        return await load()
-    }
+//    func refresh() async -> LoadingResponse<Item> {
+//        reset()
+//        return await load()
+//    }
     
     /// Loads the next page of items.
     /// - Returns: on success, .success with FetchResponse containing loaded items; if another load is underway, .ignored; if the load is cancelled, .cancelled
     func load() async -> LoadingResponse<Item> {
+        // if already loading something, ignore the request
         guard loadingTask == nil else {
-            print("DEBUG [\(Item.self) loader] ignoring request, load underway")
+            print("[\(Item.self) LoadingActor] ignoring request, load underway")
             return .failure(.ignored)
         }
+        
+        guard !done else {
+            print("[\(Item.self) LoadingActor] ignoring request, finished loading")
+            return .done(.init())
+        }
+        
+        // upon completion of load, remove loading task
+        defer { loadingTask = nil }
         
         loadingTask = Task<LoadingResponse<Item>, Error> {
             do {
                 if let cursor, page > 0 {
-                    return .success(try await fetchProvider.fetchCursor(cursor))
+                    print("[\(Item.self) LoadingActor] loading cursor \(cursor)")
+                    let response = try await fetchProvider.fetchCursor(cursor)
+                    
+                    // if same cursor returned, loading is finished
+                    if response.nextCursor == self.cursor {
+                        self.done = true
+                        return .done(response.items)
+                    }
+                    
+                    self.cursor = response.nextCursor
+                    return .success(response.items)
                 } else {
                     page += 1
-                    return .success(try await fetchProvider.fetchPage(page))
+                    print("[\(Item.self) LoadingActor] loading page \(page)")
+                    let response = try await fetchProvider.fetchPage(page)
+                    
+                    // if nothing returned, loading is finished
+                    if response.items.isEmpty {
+                        done = true
+                        return .done(.init())
+                    }
+                    self.cursor = response.nextCursor
+                    return .success(response.items)
                 }
             } catch is CancellationError {
                 return .failure(.cancelled)

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -80,7 +80,6 @@ public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
             let filteredItems = filter.filter(fetchedItems)
             processFetchedItems(filteredItems)
             newItems.append(contentsOf: filteredItems)
-            
         } while !abort && newItems.count < MiddlewareConstants.infiniteLoadThresholdOffset
         
         return newItems

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -12,13 +12,13 @@ import Observation
 @Observable
 public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
     var filter: MultiFilter<Item>
-    let fetchProvider: any FetchProviding<Item>
+    let fetcher: any Fetcher<Item>
     var loadingActor: LoadingActor<Item>
 
-    init(filter: MultiFilter<Item>, fetchProvider: any FetchProviding<Item>) {
+    init(filter: MultiFilter<Item>, fetcher: any Fetcher<Item>) {
         self.filter = filter
-        self.fetchProvider = fetchProvider
-        self.loadingActor = .init(fetchProvider: fetchProvider)
+        self.fetcher = fetcher
+        self.loadingActor = .init(fetcher: fetcher)
         super.init()
     }
 

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -12,13 +12,14 @@ import Observation
 @Observable
 public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
     var filter: MultiFilter<Item>
-    let fetchProvider: FetchProviding<Item>
+    let fetchProvider: any FetchProviding<Item>
     var loadingActor: LoadingActor<Item>
 
-    init(pageSize: Int, filter: MultiFilter<Item>, loadingActor: LoadingActor<Item>) {
+    init(filter: MultiFilter<Item>, fetchProvider: any FetchProviding<Item>) {
         self.filter = filter
-        self.loadingActor = loadingActor
-        super.init(pageSize: pageSize)
+        self.fetchProvider = fetchProvider
+        self.loadingActor = .init(fetchProvider: fetchProvider)
+        super.init()
     }
 
     // MARK: - External methods
@@ -31,7 +32,7 @@ public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
         var newItems: [Item] = .init()
         var abort: Bool = false // this is slightly awkward but lets us trigger a loop break from within the switch handlers below
         repeat {
-            print("DEBUG repeating load")
+            print("DEBUG repeating load (\(newItems.count))")
             let loadingResponse = await loadingActor.load()
             var fetchedItems: [Item] = .init()
             

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -12,10 +12,10 @@ import Observation
 @Observable
 public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
     var filter: MultiFilter<Item>
-    let fetcher: any Fetcher<Item>
+    let fetcher: Fetcher<Item>
     var loadingActor: LoadingActor<Item>
 
-    init(filter: MultiFilter<Item>, fetcher: any Fetcher<Item>) {
+    init(filter: MultiFilter<Item>, fetcher: Fetcher<Item>) {
         self.filter = filter
         self.fetcher = fetcher
         self.loadingActor = .init(fetcher: fetcher)

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -24,238 +24,66 @@ enum LoadAction {
     case loadCursor(String)
 }
 
-/// Helper struct bundling the response from a fetchPage or fetchCursor call
-public struct FetchResponse<Item: FeedLoadable> {
-    /// Items returned
-    public let items: [Item]
-    
-    /// Cursor used to fetch this response, if applicable
-    public let prevCursor: String?
-    
-    /// New cursor, if applicable
-    public let nextCursor: String?
-    
-    /// Number of items filtered out
-    public let numFiltered: Int
-    
-    /// True if the response has content, false otherwise. It is possible for a filter to remove all fetched items; this avoids that triggering an erroneous end of feed.
-    public var hasContent: Bool {
-        (prevCursor == nil || nextCursor != prevCursor) && // if cursor used to fetch, ensure same cursor not returned
-        items.count + numFiltered > 0 // total sum of fetched items non-zero
-    }
-}
-
 @Observable
 public class StandardFeedLoader<Item: FeedLoadable>: CoreFeedLoader<Item> {
     var filter: MultiFilter<Item>
     /// loading state
     /// number of the most recently loaded page. 0 indicates no content.
-    private(set) var page: Int = 0
+    // private(set) var page: Int = 0
     /// cursor of the most recently loaded page. nil indicates no content.
-    private(set) var loadingCursor: String?
-    private let loadingSemaphore: AsyncSemaphore = .init(value: 1)
+    // private(set) var loadingCursor: String?
+    // private let loadingSemaphore: AsyncSemaphore = .init(value: 1)
     
-    init(pageSize: Int, filter: MultiFilter<Item>) {
+    var loadingActor: LoadingActor<Item>
+
+    init(pageSize: Int, filter: MultiFilter<Item>, loadingActor: LoadingActor<Item>) {
         self.filter = filter
+        self.loadingActor = loadingActor
         super.init(pageSize: pageSize)
     }
 
     // MARK: - External methods
     
     override public func loadMoreItems() async throws {
-        // declare this once here to avoid nasty race conditions
-        let pageToLoad = page + 1
-        let cursorToLoad = loadingCursor
-        
-        if pageToLoad == 1 {
-            // for loading first page, always use refresh--functions identically for page and cursor
-            try await load(action: .refresh(false))
-        } else {
-            // for loading subsequent pages, use cursor if available, page otherwise
-            if let cursorToLoad {
-                try await load(action: .loadCursor(cursorToLoad))
-            } else {
-                try await load(action: .loadPage(pageToLoad))
-            }
-        }
+        await setLoading(.loading)
+        let loadingResponse = await loadingActor.load()
+        await handleLoadingResponse(loadingResponse)
     }
     
     override public func refresh(clearBeforeRefresh: Bool) async throws {
-        try await load(action: .refresh(clearBeforeRefresh))
+        if clearBeforeRefresh {
+            await setItems(.init())
+        }
+        
+        filter.reset()
+        await setLoading(.loading)
+        let loadingResponse = try await loadingActor.refresh()
+        await handleLoadingResponse(loadingResponse)
     }
 
     public func clear() async {
-        do {
-            try await load(action: .clear)
-        } catch {
-            assertionFailure("Exception thrown when resetting, this should not be possible!")
-            await clearHelper() // this is not a thread-safe use of clear, but I'm using it here because we should never get here
-        }
+        filter.reset()
+        await loadingActor.reset()
+        await setLoading(.idle)
+        await setItems(.init())
     }
 
     // MARK: - Internal methods
     
-    /// Performs the requested loading operation. To account for the fact that multiple threads might request a load at the same time, this function requires that the caller pass in what it thinks is the next page or cursor to load. If that is not the next page/cursor by the time that call is allowed to execute, its request will be ignored.
-    /// This grants this function an additional, extremely useful property: calling `await loadPage` while `loadPage` is already being executed will, practically speaking, await the in-flight request.
-    /// There is additional logic to handle the reset case--because page is updated at the end of this call, if reset() set the page to 0 itself and a reset call were made while another loading call was in-flight, the in-flight call would update page before the reset call went through and the reset call's load would be aborted. Instead, this method takes on responsibility for resetting--calling it on page 0 clears the tracker, and page 1 refreshes it
-    /// - Parameter page: page number to load
-    func load(action: LoadAction) async throws {
-        // only one thread may execute this function at a time
-        await loadingSemaphore.wait()
-        defer { loadingSemaphore.signal() }
-        
-        switch action {
-        case .clear:
-            print("[\(Item.self) tracker] clearing")
-            await clearHelper()
-        case let .refresh(clearBeforeRefresh):
-            print("[\(Item.self) tracker] refreshing")
-            try await refreshHelper(clearBeforeRefresh: clearBeforeRefresh)
-        case let .loadPage(pageToLoad):
-            print("[\(Item.self) tracker] loading page \(pageToLoad)")
-            try await loadPageHelper(pageToLoad)
-        case let .loadCursor(cursorToLoad):
-            print("[\(Item.self) tracker] loading cursor \(cursorToLoad)")
-            try await loadCursorHelper(cursorToLoad)
-        }
-    }
-    
-    /// Fetches the given page of items. This method must be overridden by the instantiating class because different items are loaded differently. The instantiating class is responsible for handling fetch parameters (e.g., page size, unread only) and performing filtering
-    /// - Parameters:
-    ///   - page: page number to fetch
-    /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
-    func fetchPage(page: Int) async throws -> FetchResponse<Item> {
-        preconditionFailure("This method must be implemented by the inheriting class")
-    }
-    
-    /// Fetches items from the given cursor. This method must be overridden by the instantiating class because different items are loaded differently. The instantiating class is responsible for handling fetch parameters (e.g., page size, unread only) and performing filtering
-    /// - Parameters:
-    ///   - cursor: cursor to fetch
-    /// - Returns: tuple of the requested page of items, the cursor returned by the API call (if present), and the number of items that were filtered out.
-    func fetchCursor(cursor: String) async throws -> FetchResponse<Item> {
-        preconditionFailure("This method must be implemented by the inheriting class")
-    }
-
-    // MARK: - Helpers
-
-    /// Clears the tracker to an empty state.
-    /// - Warning: **DO NOT** call this method from anywhere but `load`! This is *purely* a helper function for `load` and *will* lead to unexpected behavior if called elsewhere!
-    private func clearHelper() async {
-        filter.reset()
-        page = 0
-        loadingCursor = nil
-        await setLoading(.idle)
-        await setItems(.init())
-    }
-    
-    /// Clears
-    /// - Warning: **DO NOT** call this method from anywhere but `load`! This is *purely* a helper function for `load` and *will* lead to unexpected behavior if called elsewhere!
-    private func refreshHelper(clearBeforeRefresh: Bool) async throws {
-        if clearBeforeRefresh {
-            await clearHelper()
-        } else {
-            // if not clearing before reset, still clear these fields in order to sanitize the loading state--we just keep the items in place until we have received new ones, which will be set by loadPage/loadCursor
-            filter.reset()
-            page = 0
-            loadingCursor = nil
+    private func handleLoadingResponse(_ loadingResponse: LoadingResponse<Item>) async {
+        switch loadingResponse {
+        case let .success(fetchResponse):
+            print("[\(Item.self) FeedLoader] received \(fetchResponse.items.count) new items")
+            
+            if fetchResponse.hasContent {
+                await addItems(fetchResponse.items)
+                await setLoading(.idle)
+            } else {
+                await setLoading(.done)
+            }
+        case let .failure(reason):
+            print("[\(Item.self) FeedLoader] load failed (\(reason.rawValue))")
             await setLoading(.idle)
         }
-        try await loadPageHelper(1)
-    }
-    
-    /// Loads a given page of items
-    /// - Parameter pageToLoad: page to load
-    /// - Warning: **DO NOT** call this method from anywhere but `load`! This is *purely* a helper function for `load` and *will* lead to unexpected behavior if called elsewhere!
-    private func loadPageHelper(_ pageToLoad: Int) async throws {
-        // There isn't a scenario in which we have cursor available but want to load a specific page of content; either we are loading the first
-        // page or the cursor is unavailable.
-        assert(loadingCursor == nil || pageToLoad == 1, "loadPageHelper called when valid cursor available!")
-        
-        // do not continue to load if done
-        guard loadingState != .done else {
-            print("[\(Item.self) tracker] done loading, will not continue")
-            return
-        }
-
-        // do nothing if this is not the next page to load
-        guard pageToLoad == page + 1 else {
-            print("[\(Item.self) tracker] will not load page \(pageToLoad) of items (have loaded \(page) pages)")
-            return
-        }
-        
-        await setLoading(.loading)
-        
-        var newState: LoadingState = .idle
-        
-        var newItems: [Item] = .init()
-        while newItems.count < pageSize {
-            // use cursor-based fetching if available
-            let fetched: FetchResponse<Item>
-            if let loadingCursor {
-                fetched = try await fetchCursor(cursor: loadingCursor)
-            } else {
-                fetched = try await fetchPage(page: page + 1)
-            }
-            
-            page += 1
-            loadingCursor = fetched.nextCursor
-            
-            if !fetched.hasContent {
-                print("[\(Item.self) tracker] fetch returned no items, setting loading state to done")
-                newState = .done
-                break
-            }
-            
-            newItems.append(contentsOf: fetched.items)
-        }
-
-        // if loading page 1, we can just do a straight assignment regardless of whether we did clearBeforeReset
-        if pageToLoad == 1 {
-            await setItems(newItems)
-        } else {
-            await addItems(newItems)
-        }
-
-        await setLoading(newState)
-    }
-    
-    private func loadCursorHelper(_ cursor: String) async throws {
-        // do not continue to load if done
-        guard loadingState != .done else {
-            print("[\(Item.self) tracker] done loading, will not continue")
-            return
-        }
-
-        // do nothing if this is not the next page to load
-        guard cursor == loadingCursor else {
-            print("[\(Item.self) tracker] will not load cursor \(cursor) (current cursor is \(String(describing: loadingCursor))")
-            return
-        }
-        
-        await setLoading(.loading)
-        
-        var newState: LoadingState = .idle
-        
-        var cursor: String = cursor // make this mutable
-        var newItems: [Item] = .init()
-        while newItems.count < pageSize {
-            let fetched = try await fetchCursor(cursor: cursor)
-            
-            guard let fetchedCursor = fetched.nextCursor, fetched.hasContent else {
-                print("[\(Item.self) tracker] fetch returned no items or EOF cursor, setting loading state to done")
-                newState = .done
-                break
-            }
-            
-            cursor = fetchedCursor
-            page += 1 // not strictly necessary but good for tracking number of loaded pages
-            
-            newItems.append(contentsOf: fetched.items)
-        }
-        
-        loadingCursor = cursor
-        
-        await addItems(newItems)
-        await setLoading(newState)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
@@ -9,7 +9,6 @@ import Foundation
 
 class PersonFetcher: Fetcher<Person2> {
     let api: ApiClient
-    let pageSize: Int
     var query: String
     /// `listing` can be set to `.local` from 0.19.4 onwards.
     var listing: ApiListingType
@@ -17,13 +16,14 @@ class PersonFetcher: Fetcher<Person2> {
     
     init(api: ApiClient, pageSize: Int, query: String, listing: ApiListingType, sort: ApiSortType) {
         self.api = api
-        self.pageSize = pageSize
         self.query = query
         self.listing = listing
         self.sort = sort
+        
+        super.init(pageSize: pageSize)
     }
     
-    override func fetchPage(_ page: Int) async throws -> FetchResponse<Person2> {
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
         let communities = try await api.searchPeople(
             query: query,
             page: page,

--- a/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
@@ -58,30 +58,12 @@ public class PersonFeedLoader: StandardFeedLoader<Person2> {
         self.sort = sort
         
         super.init(
-            pageSize: pageSize,
             filter: .init(),
-            loadingActor: .init(fetchProvider: PersonFetchProvider(api: api, query: query, pageSize: pageSize, listing: listing, sort: sort))
+            fetchProvider: PersonFetchProvider(api: api, query: query, pageSize: pageSize, listing: listing, sort: sort)
         )
     }
     
     // MARK: StandardTracker Loading Methods
-//    
-//    override public func fetchPage(page: Int) async throws -> FetchResponse<Person2> {
-//        let communities = try await api.searchPeople(
-//            query: query,
-//            page: page,
-//            limit: pageSize,
-//            filter: listing,
-//            sort: sort
-//        )
-//
-//        return .init(
-//            items: communities,
-//            prevCursor: nil,
-//            nextCursor: nil,
-//            numFiltered: 0
-//        )
-//    }
     
     override public func refresh(clearBeforeRefresh: Bool) async throws {
         try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)

--- a/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
@@ -28,8 +28,7 @@ struct PersonFetchProvider: FetchProviding {
         return .init(
             items: communities,
             prevCursor: nil,
-            nextCursor: nil,
-            numFiltered: 0
+            nextCursor: nil
         )
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct PersonFetchProvider: FetchProviding {
+struct PersonFetcher: Fetcher {
     typealias item = Person2
     
     let api: ApiClient
@@ -59,7 +59,7 @@ public class PersonFeedLoader: StandardFeedLoader<Person2> {
         
         super.init(
             filter: .init(),
-            fetchProvider: PersonFetchProvider(api: api, query: query, pageSize: pageSize, listing: listing, sort: sort)
+            fetcher: PersonFetcher(api: api, query: query, pageSize: pageSize, listing: listing, sort: sort)
         )
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
@@ -7,6 +7,37 @@
 
 import Foundation
 
+struct PersonFetchProvider: FetchProviding {
+    typealias item = Person2
+    
+    let api: ApiClient
+    let query: String
+    let pageSize: Int
+    let listing: ApiListingType
+    let sort: ApiSortType
+    
+    func fetchPage(_ page: Int) async throws -> FetchResponse<Person2> {
+        let communities = try await api.searchPeople(
+            query: query,
+            page: page,
+            limit: pageSize,
+            filter: listing,
+            sort: sort
+        )
+
+        return .init(
+            items: communities,
+            prevCursor: nil,
+            nextCursor: nil,
+            numFiltered: 0
+        )
+    }
+    
+    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Person2> {
+        fatalError("Unsupported loading operation")
+    }
+}
+
 @Observable
 public class PersonFeedLoader: StandardFeedLoader<Person2> {
     public var api: ApiClient
@@ -29,28 +60,29 @@ public class PersonFeedLoader: StandardFeedLoader<Person2> {
         
         super.init(
             pageSize: pageSize,
-            filter: .init()
+            filter: .init(),
+            loadingActor: .init(fetchProvider: PersonFetchProvider(api: api, query: query, pageSize: pageSize, listing: listing, sort: sort))
         )
     }
     
     // MARK: StandardTracker Loading Methods
-    
-    override public func fetchPage(page: Int) async throws -> FetchResponse<Person2> {
-        let communities = try await api.searchPeople(
-            query: query,
-            page: page,
-            limit: pageSize,
-            filter: listing,
-            sort: sort
-        )
-
-        return .init(
-            items: communities,
-            prevCursor: nil,
-            nextCursor: nil,
-            numFiltered: 0
-        )
-    }
+//    
+//    override public func fetchPage(page: Int) async throws -> FetchResponse<Person2> {
+//        let communities = try await api.searchPeople(
+//            query: query,
+//            page: page,
+//            limit: pageSize,
+//            filter: listing,
+//            sort: sort
+//        )
+//
+//        return .init(
+//            items: communities,
+//            prevCursor: nil,
+//            nextCursor: nil,
+//            numFiltered: 0
+//        )
+//    }
     
     override public func refresh(clearBeforeRefresh: Bool) async throws {
         try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)

--- a/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
@@ -7,9 +7,7 @@
 
 import Foundation
 
-class PersonFetcher: Fetcher {
-    typealias item = Person2
-    
+class PersonFetcher: Fetcher<Person2> {
     let api: ApiClient
     let pageSize: Int
     var query: String
@@ -25,7 +23,7 @@ class PersonFetcher: Fetcher {
         self.sort = sort
     }
     
-    func fetchPage(_ page: Int) async throws -> FetchResponse<Person2> {
+    override func fetchPage(_ page: Int) async throws -> FetchResponse<Person2> {
         let communities = try await api.searchPeople(
             query: query,
             page: page,
@@ -41,9 +39,9 @@ class PersonFetcher: Fetcher {
         )
     }
     
-    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Person2> {
-        fatalError("Unsupported loading operation")
-    }
+//    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Person2> {
+//        fatalError("Unsupported loading operation")
+//    }
 }
 
 @Observable

--- a/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Person/PersonFeedLoader.swift
@@ -38,10 +38,6 @@ class PersonFetcher: Fetcher<Person2> {
             nextCursor: nil
         )
     }
-    
-//    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Person2> {
-//        fatalError("Unsupported loading operation")
-//    }
 }
 
 @Observable
@@ -66,12 +62,6 @@ public class PersonFeedLoader: StandardFeedLoader<Person2> {
         )
     }
     
-    // MARK: StandardTracker Loading Methods
-    
-    override public func refresh(clearBeforeRefresh: Bool) async throws {
-        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
-    }
-    
     public func refresh(
         query: String? = nil,
         listing: ApiListingType? = nil,
@@ -81,6 +71,6 @@ public class PersonFeedLoader: StandardFeedLoader<Person2> {
         personFetcher.query = query ?? personFetcher.query
         personFetcher.listing = listing ?? personFetcher.listing
         personFetcher.sort = sort ?? personFetcher.sort
-        try await refresh(clearBeforeRefresh: clearBeforeRefresh)
+        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class AggregatePostFetchProvider: PostFetchProvider {
+class AggregatePostFetcher: PostFetcher {
     var feedType: ApiListingType
     
     init(api: ApiClient, feedType: ApiListingType, sortType: ApiSortType, pageSize: Int) {
@@ -32,8 +32,8 @@ class AggregatePostFetchProvider: PostFetchProvider {
 public class AggregatePostFeedLoader: CorePostFeedLoader {
     public var api: ApiClient
     
-    // force unwrap because this should ALWAYS be an AggregatePostFetchProvider
-    var aggregatePostFetchProvider: AggregatePostFetchProvider { fetchProvider as! AggregatePostFetchProvider }
+    // force unwrap because this should ALWAYS be an AggregatePostFetcher
+    var aggregatePostFetcher: AggregatePostFetcher { fetcher as! AggregatePostFetcher }
     
     public init(
         pageSize: Int,
@@ -52,7 +52,7 @@ public class AggregatePostFeedLoader: CorePostFeedLoader {
             showReadPosts: showReadPosts,
             filteredKeywords: filteredKeywords,
             prefetchingConfiguration: prefetchingConfiguration,
-            fetchProvider: AggregatePostFetchProvider(
+            fetcher: AggregatePostFetcher(
                 api: api,
                 feedType: feedType,
                 sortType: sortType,
@@ -63,10 +63,10 @@ public class AggregatePostFeedLoader: CorePostFeedLoader {
     
     @MainActor
     public func changeFeedType(to newFeedType: ApiListingType) async throws {
-        let shouldRefresh = items.isEmpty || aggregatePostFetchProvider.feedType != newFeedType
+        let shouldRefresh = items.isEmpty || aggregatePostFetcher.feedType != newFeedType
         
         // always perform assignment--if account changed, feed type will look unchanged but API will be different
-        aggregatePostFetchProvider.feedType = newFeedType
+        aggregatePostFetcher.feedType = newFeedType
         
         // only refresh if nominal feed type changed
         if shouldRefresh {

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
@@ -30,8 +30,6 @@ class AggregatePostFetcher: PostFetcher {
 }
 
 public class AggregatePostFeedLoader: CorePostFeedLoader {
-    public var api: ApiClient
-    
     // force unwrap because this should ALWAYS be an AggregatePostFetcher
     var aggregatePostFetcher: AggregatePostFetcher { fetcher as! AggregatePostFetcher }
     
@@ -45,7 +43,6 @@ public class AggregatePostFeedLoader: CorePostFeedLoader {
         api: ApiClient,
         feedType: ApiListingType
     ) {
-        self.api = api
         super.init(
             api: api,
             pageSize: pageSize,
@@ -72,5 +69,9 @@ public class AggregatePostFeedLoader: CorePostFeedLoader {
         if shouldRefresh {
             try await refresh(clearBeforeRefresh: true)
         }
+    }
+    
+    public func changeApi(to newApi: ApiClient) {
+        aggregatePostFetcher.api = newApi
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
@@ -9,15 +9,11 @@ import Foundation
 
 class AggregatePostFetchProvider: PostFetchProvider {
     var feedType: ApiListingType
-    var sortType: ApiSortType
-    var pageSize: Int
     
     init(api: ApiClient, feedType: ApiListingType, sortType: ApiSortType, pageSize: Int) {
         self.feedType = feedType
-        self.sortType = sortType
-        self.pageSize = pageSize
         
-        super.init(api: api)
+        super.init(api: api, sortType: sortType, pageSize: pageSize)
     }
     
     override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
@@ -52,14 +48,11 @@ public class AggregatePostFeedLoader: CorePostFeedLoader {
         super.init(
             api: api,
             pageSize: pageSize,
-            sortType: sortType,
             showReadPosts: showReadPosts,
             filteredKeywords: filteredKeywords,
             prefetchingConfiguration: prefetchingConfiguration,
             fetchProvider: AggregatePostFetchProvider(
                 api: api,
-                filter: PostFilter(showRead: showReadPosts),
-                prefetchingConfiguration: prefetchingConfiguration,
                 feedType: feedType,
                 sortType: sortType,
                 pageSize: pageSize

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/AggregatePostFeedLoader.swift
@@ -8,16 +8,16 @@
 import Foundation
 
 class AggregatePostFetchProvider: PostFetchProvider {
-    let feedType: ApiListingType
-    let sortType: ApiSortType
-    let pageSize: Int
+    var feedType: ApiListingType
+    var sortType: ApiSortType
+    var pageSize: Int
     
-    init(api: ApiClient, filter: PostFilter, prefetchingConfiguration: PrefetchingConfiguration, feedType: ApiListingType, sortType: ApiSortType, pageSize: Int) {
+    init(api: ApiClient, feedType: ApiListingType, sortType: ApiSortType, pageSize: Int) {
         self.feedType = feedType
         self.sortType = sortType
         self.pageSize = pageSize
         
-        super.init(api: api, filter: filter, prefetchingConfiguration: prefetchingConfiguration)
+        super.init(api: api)
     }
     
     override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
@@ -7,6 +7,27 @@
 
 import Foundation
 
+class CommunityPostFetchProvider: PostFetchProvider {
+    var community: any Community
+    
+    init(sortType: ApiSortType, pageSize: Int, community: any Community) {
+        self.community = community
+        
+        super.init(api: community.api, sortType: sortType, pageSize: pageSize)
+    }
+    
+    override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
+        return try await community.getPosts(
+            sort: sortType,
+            page: page,
+            cursor: cursor,
+            limit: pageSize,
+            filter: nil, // TODO
+            showHidden: false // TODO
+        )
+    }
+}
+
 public class CommunityPostFeedLoader: CorePostFeedLoader {
     public var community: any Community
     
@@ -23,21 +44,10 @@ public class CommunityPostFeedLoader: CorePostFeedLoader {
         super.init(
             api: community.api,
             pageSize: pageSize,
-            sortType: sortType,
             showReadPosts: showReadPosts,
             filteredKeywords: filteredKeywords,
-            prefetchingConfiguration: prefetchingConfiguration
+            prefetchingConfiguration: prefetchingConfiguration,
+            fetchProvider: CommunityPostFetchProvider(sortType: sortType, pageSize: pageSize, community: community)
         )
     }
-    
-//    override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
-//        return try await community.getPosts(
-//            sort: sortType,
-//            page: page,
-//            cursor: cursor,
-//            limit: pageSize,
-//            filter: nil, // TODO
-//            showHidden: false // TODO
-//        )
-//    }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
@@ -21,6 +21,7 @@ public class CommunityPostFeedLoader: CorePostFeedLoader {
     ) {
         self.community = community
         super.init(
+            api: community.api,
             pageSize: pageSize,
             sortType: sortType,
             showReadPosts: showReadPosts,

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class CommunityPostFetchProvider: PostFetchProvider {
+class CommunityPostFetcher: PostFetcher {
     var community: any Community
     
     init(sortType: ApiSortType, pageSize: Int, community: any Community) {
@@ -47,7 +47,7 @@ public class CommunityPostFeedLoader: CorePostFeedLoader {
             showReadPosts: showReadPosts,
             filteredKeywords: filteredKeywords,
             prefetchingConfiguration: prefetchingConfiguration,
-            fetchProvider: CommunityPostFetchProvider(sortType: sortType, pageSize: pageSize, community: community)
+            fetcher: CommunityPostFetcher(sortType: sortType, pageSize: pageSize, community: community)
         )
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CommunityPostFeedLoader.swift
@@ -30,14 +30,14 @@ public class CommunityPostFeedLoader: CorePostFeedLoader {
         )
     }
     
-    override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
-        return try await community.getPosts(
-            sort: sortType,
-            page: page,
-            cursor: cursor,
-            limit: pageSize,
-            filter: nil, // TODO
-            showHidden: false // TODO
-        )
-    }
+//    override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
+//        return try await community.getPosts(
+//            sort: sortType,
+//            page: page,
+//            cursor: cursor,
+//            limit: pageSize,
+//            filter: nil, // TODO
+//            showHidden: false // TODO
+//        )
+//    }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -9,9 +9,7 @@ import Foundation
 import Nuke
 import Observation
 
-public class PostFetcher: Fetcher {
-    typealias Item = Post2
-    
+public class PostFetcher: Fetcher<Post2> {
     var api: ApiClient
     var sortType: ApiSortType
     var pageSize: Int
@@ -22,7 +20,7 @@ public class PostFetcher: Fetcher {
         self.pageSize = pageSize
     }
     
-    func fetchPage(_ page: Int) async throws -> FetchResponse<Post2> {
+    override func fetchPage(_ page: Int) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: page, cursor: nil)
 
         return .init(
@@ -32,7 +30,7 @@ public class PostFetcher: Fetcher {
         )
     }
     
-    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Post2> {
+    override func fetchCursor(_ cursor: String) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: 1, cursor: cursor)
         
         return .init(

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -25,26 +25,24 @@ class PostFetchProvider: FetchProviding {
     func fetchPage(_ page: Int) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: page, cursor: nil)
 
-        let filteredPosts = filter.filter(result.posts)
+        let filteredPosts = result.posts
         preloadImages(filteredPosts)
         return .init(
             items: filteredPosts,
             prevCursor: nil,
-            nextCursor: result.cursor,
-            numFiltered: result.posts.count - filteredPosts.count
+            nextCursor: result.cursor
         )
     }
     
     func fetchCursor(_ cursor: String) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: 1, cursor: cursor)
 
-        let filteredPosts = filter.filter(result.posts)
+        let filteredPosts = result.posts
         preloadImages(filteredPosts)
         return .init(
             items: filteredPosts,
             prevCursor: cursor,
-            nextCursor: result.cursor,
-            numFiltered: result.posts.count - filteredPosts.count
+            nextCursor: result.cursor
         )
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -100,7 +100,6 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     /// Use in situations where filtering is handled client-side (e.g., filtering read posts or keywords)
     /// - Parameter newFilter: NewPostFilterReason describing the filter to apply
     public func addFilter(_ newFilter: PostFilterType) async throws {
-        print("DEBUG \(loadingState)")
         if filter.activate(newFilter) {
             await setItems(filter.reset(with: items))
             

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -9,35 +9,20 @@ import Foundation
 import Nuke
 import Observation
 
-/// Post tracker for use with single feeds. Can easily be extended to load any pure post feed by creating an inheriting class that overrides getPosts().
-@Observable
-public class CorePostFeedLoader: StandardFeedLoader<Post2> {
-    public var sortType: ApiSortType
-    public private(set) var prefetchingConfiguration: PrefetchingConfiguration
+class PostFetchProvider: FetchProviding {
+    typealias Item = Post2
     
-    public init(
-        pageSize: Int,
-        sortType: ApiSortType,
-        showReadPosts: Bool,
-        filteredKeywords: [String],
-        prefetchingConfiguration: PrefetchingConfiguration
-    ) {
-        self.sortType = sortType
+    let api: ApiClient
+    let filter: PostFilter
+    let prefetchingConfiguration: PrefetchingConfiguration
+    
+    init(api: ApiClient, filter: PostFilter, prefetchingConfiguration: PrefetchingConfiguration) {
+        self.api = api
+        self.filter = filter
         self.prefetchingConfiguration = prefetchingConfiguration
-        
-        super.init(
-            pageSize: pageSize,
-            filter: PostFilter(showRead: showReadPosts)
-        )
     }
     
-    override public func refresh(clearBeforeRefresh: Bool) async throws {
-        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
-    }
-    
-    // MARK: StandardTracker Loading Methods
-    
-    override public func fetchPage(page: Int) async throws -> FetchResponse<Post2> {
+    func fetchPage(_ page: Int) async throws -> FetchResponse<Post2> {
         let result = try await getPosts(page: page, cursor: nil)
 
         let filteredPosts = filter.filter(result.posts)
@@ -50,8 +35,8 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
         )
     }
     
-    override public func fetchCursor(cursor: String?) async throws -> FetchResponse<Post2> {
-        let result = try await getPosts(page: page, cursor: cursor)
+    func fetchCursor(_ cursor: String) async throws -> FetchResponse<Post2> {
+        let result = try await getPosts(page: 1, cursor: cursor)
 
         let filteredPosts = filter.filter(result.posts)
         preloadImages(filteredPosts)
@@ -62,6 +47,99 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
             numFiltered: result.posts.count - filteredPosts.count
         )
     }
+    
+    internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
+        preconditionFailure("This method must be implemented by the inheriting class")
+    }
+    
+    /// Preloads images for the given post
+    private func preloadImages(_ posts: [Post2]) {
+        prefetchingConfiguration.prefetcher.startPrefetching(with: posts.flatMap {
+            $0.imageRequests(configuration: prefetchingConfiguration)
+        })
+    }
+}
+
+/// Post tracker for use with single feeds. Can easily be extended to load any pure post feed by creating an inheriting class that overrides getPosts().
+@Observable
+public class CorePostFeedLoader: StandardFeedLoader<Post2> {
+    public var sortType: ApiSortType
+    public private(set) var prefetchingConfiguration: PrefetchingConfiguration
+    
+    public init(
+        api: ApiClient,
+        pageSize: Int,
+        sortType: ApiSortType,
+        showReadPosts: Bool,
+        filteredKeywords: [String],
+        prefetchingConfiguration: PrefetchingConfiguration
+    ) {
+        assertionFailure("This initializer should not be called")
+        
+        self.sortType = sortType
+        self.prefetchingConfiguration = prefetchingConfiguration
+        
+        let filter = PostFilter(showRead: showReadPosts)
+        
+        super.init(
+            pageSize: pageSize,
+            filter: filter,
+            loadingActor: .init(fetchProvider: PostFetchProvider(api: api, filter: filter, prefetchingConfiguration: prefetchingConfiguration))
+        )
+    }
+    
+    internal init(
+        api: ApiClient,
+        pageSize: Int,
+        sortType: ApiSortType,
+        showReadPosts: Bool,
+        filteredKeywords: [String],
+        prefetchingConfiguration: PrefetchingConfiguration,
+        fetchProvider: PostFetchProvider
+    ) {
+        self.sortType = sortType
+        self.prefetchingConfiguration = prefetchingConfiguration
+        
+        let filter = PostFilter(showRead: showReadPosts)
+        
+        super.init(
+            pageSize: pageSize,
+            filter: filter,
+            loadingActor: .init(fetchProvider: fetchProvider)
+        )
+    }
+    
+    override public func refresh(clearBeforeRefresh: Bool) async throws {
+        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
+    }
+    
+    // MARK: StandardTracker Loading Methods
+    
+//    override public func fetchPage(page: Int) async throws -> FetchResponse<Post2> {
+//        let result = try await getPosts(page: page, cursor: nil)
+//
+//        let filteredPosts = filter.filter(result.posts)
+//        preloadImages(filteredPosts)
+//        return .init(
+//            items: filteredPosts,
+//            prevCursor: nil,
+//            nextCursor: result.cursor,
+//            numFiltered: result.posts.count - filteredPosts.count
+//        )
+//    }
+//    
+//    override public func fetchCursor(cursor: String?) async throws -> FetchResponse<Post2> {
+//        let result = try await getPosts(page: page, cursor: cursor)
+//
+//        let filteredPosts = filter.filter(result.posts)
+//        preloadImages(filteredPosts)
+//        return .init(
+//            items: filteredPosts,
+//            prevCursor: cursor,
+//            nextCursor: result.cursor,
+//            numFiltered: result.posts.count - filteredPosts.count
+//        )
+//    }
     
     internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
         preconditionFailure("This method must be implemented by the inheriting class")
@@ -103,15 +181,16 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
         return filter.numFiltered(for: toCount)
     }
     
-    /// Preloads images for the given post
-    private func preloadImages(_ posts: [Post2]) {
-        prefetchingConfiguration.prefetcher.startPrefetching(with: posts.flatMap {
-            $0.imageRequests(configuration: prefetchingConfiguration)
-        })
-    }
+//    /// Preloads images for the given post
+//    private func preloadImages(_ posts: [Post2]) {
+//        prefetchingConfiguration.prefetcher.startPrefetching(with: posts.flatMap {
+//            $0.imageRequests(configuration: prefetchingConfiguration)
+//        })
+//    }
     
     public func setPrefetchingConfiguration(_ config: PrefetchingConfiguration) {
-        prefetchingConfiguration = config
-        preloadImages(items)
+        print("TODO")
+//        prefetchingConfiguration = config
+//        preloadImages(items)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -73,10 +73,6 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
         )
     }
     
-    override public func refresh(clearBeforeRefresh: Bool) async throws {
-        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
-    }
-    
     // MARK: StandardFeedLoader Loading Methods
   
     override func processFetchedItems(_ items: [Post2]) {

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -12,15 +12,15 @@ import Observation
 public class PostFetcher: Fetcher<Post2> {
     var api: ApiClient
     var sortType: ApiSortType
-    var pageSize: Int
     
     init(api: ApiClient, sortType: ApiSortType, pageSize: Int) {
         self.api = api
         self.sortType = sortType
-        self.pageSize = pageSize
+        
+        super.init(pageSize: pageSize)
     }
     
-    override func fetchPage(_ page: Int) async throws -> FetchResponse<Post2> {
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
         let result = try await getPosts(page: page, cursor: nil)
 
         return .init(
@@ -30,7 +30,7 @@ public class PostFetcher: Fetcher<Post2> {
         )
     }
     
-    override func fetchCursor(_ cursor: String) async throws -> FetchResponse<Post2> {
+    override func fetchCursor(_ cursor: String) async throws -> FetchResponse {
         let result = try await getPosts(page: 1, cursor: cursor)
         
         return .init(

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -9,7 +9,7 @@ import Foundation
 import Nuke
 import Observation
 
-public class PostFetchProvider: FetchProviding {
+public class PostFetcher: Fetcher {
     typealias Item = Post2
     
     var api: ApiClient
@@ -52,10 +52,10 @@ public class PostFetchProvider: FetchProviding {
 public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     public private(set) var prefetchingConfiguration: PrefetchingConfiguration
     
-    // force unwrap because this should ALWAYS be a PostFetchProvider
-    private var postFetchProvider: PostFetchProvider { fetchProvider as! PostFetchProvider }
+    // force unwrap because this should ALWAYS be a PostFetcher
+    private var postFetcher: PostFetcher { fetcher as! PostFetcher }
     
-    public var sortType: ApiSortType { postFetchProvider.sortType }
+    public var sortType: ApiSortType { postFetcher.sortType }
     
     internal init(
         api: ApiClient,
@@ -63,7 +63,7 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
         showReadPosts: Bool,
         filteredKeywords: [String],
         prefetchingConfiguration: PrefetchingConfiguration,
-        fetchProvider: PostFetchProvider
+        fetcher: PostFetcher
     ) {
         self.prefetchingConfiguration = prefetchingConfiguration
         
@@ -71,7 +71,7 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
         
         super.init(
             filter: filter,
-            fetchProvider: fetchProvider
+            fetcher: fetcher
         )
     }
     
@@ -90,11 +90,11 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     /// Changes the post sort type to the specified value and reloads the feed
     public func changeSortType(to newSortType: ApiSortType, forceRefresh: Bool = false) async throws {
         // don't do anything if sort type not changed
-        guard postFetchProvider.sortType != newSortType || forceRefresh else {
+        guard postFetcher.sortType != newSortType || forceRefresh else {
             return
         }
         
-        postFetchProvider.sortType = newSortType
+        postFetcher.sortType = newSortType
         try await refresh(clearBeforeRefresh: true)
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/CorePostFeedLoader.swift
@@ -102,6 +102,7 @@ public class CorePostFeedLoader: StandardFeedLoader<Post2> {
     /// Use in situations where filtering is handled client-side (e.g., filtering read posts or keywords)
     /// - Parameter newFilter: NewPostFilterReason describing the filter to apply
     public func addFilter(_ newFilter: PostFilterType) async throws {
+        print("DEBUG \(loadingState)")
         if filter.activate(newFilter) {
             await setItems(filter.reset(with: items))
             

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
@@ -41,16 +41,16 @@ public class SearchPostFeedLoader: CorePostFeedLoader {
         )
     }
     
-    override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
-        let response = try await api.searchPosts(
-            query: query,
-            page: page,
-            limit: pageSize,
-            communityId: communityId,
-            creatorId: creatorId,
-            filter: listing,
-            sort: sortType
-        )
-        return (posts: response, cursor: nil)
-    }
+//    override internal func getPosts(page: Int, cursor: String?) async throws -> (posts: [Post2], cursor: String?) {
+//        let response = try await api.searchPosts(
+//            query: query,
+//            page: page,
+//            limit: pageSize,
+//            communityId: communityId,
+//            creatorId: creatorId,
+//            filter: listing,
+//            sort: sortType
+//        )
+//        return (posts: response, cursor: nil)
+//    }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class SearchPostFetchProvider: PostFetchProvider {
+public class SearchPostFetcher: PostFetcher {
     public var query: String
     public var communityId: Int?
     public var creatorId: Int?
@@ -42,8 +42,8 @@ public class SearchPostFetchProvider: PostFetchProvider {
 
 public class SearchPostFeedLoader: CorePostFeedLoader {
     
-    // force unwrap because this should ALWAYS be a SearchPostFetchProvider
-    public var searchPostFetchProvider: SearchPostFetchProvider { fetchProvider as! SearchPostFetchProvider }
+    // force unwrap because this should ALWAYS be a SearchPostFetcher
+    public var searchPostFetcher: SearchPostFetcher { fetcher as! SearchPostFetcher }
     
     public init(
         api: ApiClient,
@@ -63,7 +63,7 @@ public class SearchPostFeedLoader: CorePostFeedLoader {
             showReadPosts: true,
             filteredKeywords: filteredKeywords,
             prefetchingConfiguration: prefetchingConfiguration,
-            fetchProvider: SearchPostFetchProvider(
+            fetcher: SearchPostFetcher(
                 api: api,
                 sortType: sortType,
                 pageSize: pageSize,

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
@@ -32,6 +32,7 @@ public class SearchPostFeedLoader: CorePostFeedLoader {
         self.creatorId = creatorId
         self.communityId = communityId
         super.init(
+            api: api,
             pageSize: pageSize,
             sortType: sortType,
             showReadPosts: true,

--- a/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Post Feed Loaders/SearchPostFeedLoader.swift
@@ -73,5 +73,6 @@ public class SearchPostFeedLoader: CorePostFeedLoader {
                 listing: listing
             )
         )
+        loadingState = .idle
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
@@ -109,8 +109,6 @@ class PersonContentFetcher: Fetcher<PersonContent> {
 }
 
 public class PersonContentFeedLoader: StandardFeedLoader<PersonContent> {
-    // public private(set) var prefetchingConfiguration: PrefetchingConfiguration
-    
     // force unwrap because this should ALWAYS be an AggregatePostFetcher
     var personContentFetcher: PersonContentFetcher { fetcher as! PersonContentFetcher }
     
@@ -184,10 +182,10 @@ public class PersonContentFeedLoader: StandardFeedLoader<PersonContent> {
     
     public func setPrefetchingConfiguration(_ config: PrefetchingConfiguration) {
         postStream.prefetchingConfiguration = config
-        postStream.preloadImages(items)
-        
-        // note that this currently doesn't do anything because comments don't support prefetching yet [Eric 2024.11.13]
         commentStream.prefetchingConfiguration = config
+        
+        postStream.preloadImages(items)
+        // note that this currently doesn't do anything because comments don't support prefetching yet [Eric 2024.11.13]
         commentStream.preloadImages(items)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
@@ -149,15 +149,29 @@ public class PersonContentFeedLoader: StandardFeedLoader<PersonContent> {
         ))
     }
     
+    // MARK: Custom Behavior
+    
+    override public func refresh(clearBeforeRefresh: Bool) async throws {
+        if !clearBeforeRefresh {
+            tempPostStream = postStream
+            tempCommentStream = commentStream
+        }
+        
+        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
+        
+        tempPostStream = nil
+        tempCommentStream = nil
+    }
+    
     public func changeUser(api: ApiClient, userId: Int) async {
+        tempPostStream = postStream
+        tempCommentStream = commentStream
+        
         personContentFetcher.api = api
         personContentFetcher.userId = userId
-        personContentFetcher.reset()
         await loadingActor.reset()
         await setLoading(.done) // prevent loading more items until refreshed
     }
-
-    // MARK: Custom Behavior
     
     public func loadIfThreshold(_ item: PersonContent, asChild: Bool) throws {
         let shouldLoad: Bool

--- a/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
@@ -145,13 +145,6 @@ public class PersonContentFeedLoader: StandardFeedLoader<PersonContent> {
         )
     }
     
-    // MARK: Custom Behavior
-    
-    override public func refresh(clearBeforeRefresh: Bool) async throws {
-        personContentFetcher.reset()
-        try await super.refresh(clearBeforeRefresh: clearBeforeRefresh)
-    }
-    
     public func changeUser(api: ApiClient, userId: Int) async {
         personContentFetcher.api = api
         personContentFetcher.userId = userId
@@ -159,147 +152,54 @@ public class PersonContentFeedLoader: StandardFeedLoader<PersonContent> {
         await loadingActor.reset()
         await setLoading(.done) // prevent loading more items until refreshed
     }
-}
+    
+    // MARK: StandardFeedLoader Loading Methods
+  
+    override func processFetchedItems(_ items: [PersonContent]) {
+        preloadImages(items)
+    }
+    
+    // MARK: Custom Behavior
+    
+    public func loadIfThreshold(_ item: PersonContent, asChild: Bool) throws {
+        let shouldLoad: Bool
+        if asChild {
+            shouldLoad = switch item.wrappedValue {
+            case .post: postStream.thresholds.isThreshold(item)
+            case .comment: commentStream.thresholds.isThreshold(item)
+            }
+        } else {
+            shouldLoad = thresholds.isThreshold(item)
+        }
+        
+        // regardless of which threshold triggers this, always call loadMoreItems() because there's no item-specific endpoint
+        if shouldLoad {
+            Task(priority: .userInitiated) {
+                try await loadMoreItems()
+            }
+        }
+    }
+    
+    public func setPrefetchingConfiguration(_ config: PrefetchingConfiguration) {
+        prefetchingConfiguration = config
+        preloadImages(items)
+    }
 
-//@Observable
-//public class PersonContentFeedLoader: FeedLoading {
-//    // public var api: ApiClient
-//    public var items: [PersonContent]
-//    public var loadingState: LoadingState
-//    
-//    public var prefetchingConfiguration: PrefetchingConfiguration
-//    
-//    let fetcher: PersonContentFetcher
-//
-//    private var thresholds: Thresholds<PersonContent> = .init()
-//    
-//    private var postStream: PersonContentStream<Post2> { fetcher.postStream }
-//    private var commentStream: PersonContentStream<Comment2> { fetcher.commentStream }
-//    
-//    // these are used to allow refresh without clear
-//    private var tempPostStream: PersonContentStream<Post2>?
-//    private var tempCommentStream: PersonContentStream<Comment2>?
-//    
-//    // convenience accessors for child types
-//    public var posts: [PersonContent] { tempPostStream?.items ?? postStream.items }
-//    public var postLoadingState: LoadingState { postStream.doneLoading ? .done : loadingState }
-//    
-//    public var comments: [PersonContent] { tempCommentStream?.items ?? commentStream.items }
-//    public var commentLoadingState: LoadingState { commentStream.doneLoading ? .done : loadingState }
-//    
-//    public init(
-//        api: ApiClient,
-//        userId: Int,
-//        sortType: FeedLoaderSort.SortType,
-//        savedOnly: Bool,
-//        prefetchingConfiguration: PrefetchingConfiguration,
-//        withContent: (posts: [Post2], comments: [Comment2])? = nil
-//    ) {
-//        self.items = .init()
-//        self.loadingState = .loading
-//        self.fetcher = .init(api: api, sortType: sortType, userId: userId, savedOnly: savedOnly, withContent: withContent)
-//        self.prefetchingConfiguration = prefetchingConfiguration
-//    }
-//    
-//    // MARK: Public Methods
-//    
-//    public func switchUser(api: ApiClient, userId: Int) async {
-//        // self.api = api
-//        // self.userId = userId
-//        fetcher.api = api
-//        fetcher.userId = userId
-//        await setLoadingState(.done) // prevent loading more items until refresh
-//    }
-//    
-//    // protocol conformance
-//    public func loadIfThreshold(_ item: PersonContent) throws {
-//        try loadIfThreshold(item, asChild: false)
-//    }
-//    
-//    /// Given a PersonContent, loads more items if that content is a threshold item
-//    /// - Parameters:
-//    ///   - item: PersonContent
-//    ///   - loadChildOnly: if true, the item will be evaluated against the relevant stream threshold rather than the parent threshold
-//    public func loadIfThreshold(_ item: PersonContent, asChild: Bool) throws {
-//        let shouldLoad: Bool
-//        if asChild {
-//            shouldLoad = switch item.wrappedValue {
-//            case .post: postStream.thresholds.isThreshold(item)
-//            case .comment: commentStream.thresholds.isThreshold(item)
-//            }
-//        } else {
-//            shouldLoad = thresholds.isThreshold(item)
-//        }
-//        
-//        // regardless of which threshold triggers this, always call loadMoreItems() because there's no item-specific endpoint
-//        if shouldLoad {
-//            Task(priority: .userInitiated) {
-//                try await loadMoreItems()
-//            }
-//        }
-//    }
-//    
-//    public func loadMoreItems() async throws {
-//        // TODO: implement with LoadingActor
-//        // print("Loading more user content")
-//        // try await loadContentPage(contentPage + 1)
-//    }
-//    
-//    public func changeSortType(to sortType: FeedLoaderSort.SortType) {
-//        items = .init()
-//        fetcher.sortType = sortType
-//        fetcher.postStream = .init()
-//        fetcher.commentStream = .init()
-//    }
-//    
-//    public func refresh(clearBeforeRefresh: Bool) async throws {
-//        await setLoadingState(.loading)
-//        
-//        if clearBeforeRefresh {
-//            items = .init()
-//        } else {
-//            tempPostStream = postStream
-//            tempCommentStream = commentStream
-//        }
-//        fetcher.reset()
-//        defer {
-//            tempPostStream = nil
-//            tempCommentStream = nil
-//        }
-//        try await loadMoreItems()
-//    }
-//    
-//    @MainActor
-//    public func clear() {
-//        items = .init()]
-//        tempPostStream = nil
-//        tempCommentStream = nil
-//        fetcher.reset()
-//        loadingState = .idle
-//    }
-//    
-//    // MARK: Private Methods
-//    
-//    // MARK: Helpers
-//    
-//    @MainActor
-//    private func setLoadingState(_ newState: LoadingState) {
-//        loadingState = newState
-//    }
-//    
-//    @MainActor
-//    private func addItems(_ newItems: [PersonContent]) {
-//        items.append(contentsOf: newItems)
-//    }
-//    
-//    @MainActor
-//    private func setItems(_ newItems: [PersonContent]) {
-//        items = newItems
-//    }
-//    /// Preloads images for the given post
-//    private func preloadImages(_ posts: [Post2]) {
-//        prefetchingConfiguration.prefetcher.startPrefetching(with: posts.flatMap {
-//            $0.imageRequests(configuration: prefetchingConfiguration)
-//        })
-//    }
-//}
+    /// Preloads images for the given PersonContent
+    private func preloadImages(_ items: [PersonContent]) {
+        // TODO: prefetch comment images
+        var numPosts: Int = 0
+        var imageRequests = items.flatMap { item in
+            switch item.wrappedValue {
+            case let .post(post):
+                numPosts += 1
+                return post.imageRequests(configuration: prefetchingConfiguration)
+            default: return []
+            }
+        }
+        
+        print("DEBUG prefetching \(imageRequests.count) images for \(numPosts) posts")
+        
+        prefetchingConfiguration.prefetcher.startPrefetching(with: imageRequests)
+    }
+}

--- a/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentFeedLoader.swift
@@ -20,7 +20,6 @@ import Nuke
 
 class PersonContentFetcher: Fetcher<PersonContent> {
     var api: ApiClient
-    var pageSize: Int
     var sortType: FeedLoaderSort.SortType
     var userId: Int
     var savedOnly: Bool
@@ -38,14 +37,13 @@ class PersonContentFetcher: Fetcher<PersonContent> {
         prefetchingConfiguration: PrefetchingConfiguration
     ) {
         self.api = api
-        self.pageSize = pageSize
         self.sortType = sortType
         self.userId = userId
         self.savedOnly = savedOnly
         self.postStream = .init(items: withContent?.posts, prefetchingConfiguration: prefetchingConfiguration)
         self.commentStream = .init(items: withContent?.comments, prefetchingConfiguration: prefetchingConfiguration)
         
-        super.init(page: withContent == nil ? 0 : 1)
+        super.init(pageSize: pageSize, page: withContent == nil ? 0 : 1)
     }
     
     override func reset() {
@@ -72,11 +70,11 @@ class PersonContentFetcher: Fetcher<PersonContent> {
         return .success(newItems)
     }
     
-    override func fetchPage(_ page: Int) async throws -> FetchResponse<PersonContent> {
+    override func fetchPage(_ page: Int) async throws -> FetchResponse {
         fatalError("Unsupported loading operation")
     }
     
-    override func fetchCursor(_ cursor: String) async throws -> FetchResponse<PersonContent> {
+    override func fetchCursor(_ cursor: String) async throws -> FetchResponse {
         fatalError("Unsupported loading operation")
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentStream.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentStream.swift
@@ -84,8 +84,6 @@ public class PersonContentStream<Item: PersonContentProviding> {
             }
         }
         
-        print("DEBUG prefetching \(imageRequests.count) images for \(numPosts) posts")
-        
         prefetchingConfiguration.prefetcher.startPrefetching(with: imageRequests)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentStream.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentStream.swift
@@ -9,15 +9,17 @@ import Foundation
 
 // This struct is just a convenience wrapper to handle stream state--all loading operations happen at the FeedLoader level to 
 // avoid parent/child concurrency control hell
-public struct PersonContentStream<Item: PersonContentProviding> {
+public class PersonContentStream<Item: PersonContentProviding> {
     // From the frontend it is more ergonomic to have these be PersonContent. These are guaranteed to all be of type Item by
     // guarding assignment behind `init` and `addItems`, which can only take Item.
     private(set) var items: [PersonContent]
     var cursor: Int = 0
     var doneLoading: Bool = false
     var thresholds: Thresholds<PersonContent>
+    var prefetchingConfiguration: PrefetchingConfiguration
     
-    init(items: [Item]? = nil) {
+    init(items: [Item]? = nil, prefetchingConfiguration: PrefetchingConfiguration) {
+        self.prefetchingConfiguration = prefetchingConfiguration
         self.thresholds = .init()
         if let items {
             let personContentItems: [PersonContent] = items.map { $0.userContent }
@@ -30,8 +32,15 @@ public struct PersonContentStream<Item: PersonContentProviding> {
     
     var needsMoreItems: Bool { !doneLoading && cursor >= items.count }
     
-    mutating func addItems(_ newItems: [Item]) {
+    func reset() {
+        cursor = 0
+        doneLoading = false
+        thresholds = .init()
+    }
+    
+    func addItems(_ newItems: [Item]) {
         let personContentItems: [PersonContent] = newItems.map { $0.userContent }
+        preloadImages(personContentItems)
         items.append(contentsOf: personContentItems)
         thresholds.update(with: personContentItems)
         if newItems.isEmpty {
@@ -53,12 +62,30 @@ public struct PersonContentStream<Item: PersonContentProviding> {
     /// Gets the next item in the stream and increments the cursor
     /// - Returns: next item in the feed stream
     /// - Warning: This is NOT a thread-safe function! Only one thread at a time per stream may call this function!
-    mutating func consumeNextItem() -> PersonContent? {
+    func consumeNextItem() -> PersonContent? {
         guard cursor < items.count else {
             return nil
         }
         
         cursor += 1
         return items[cursor - 1]
+    }
+    
+    /// Preloads images for the given PersonContent items
+    func preloadImages(_ items: [PersonContent]) {
+        // TODO: prefetch comment images
+        var numPosts: Int = 0
+        var imageRequests = items.flatMap { item in
+            switch item.wrappedValue {
+            case let .post(post):
+                numPosts += 1
+                return post.imageRequests(configuration: prefetchingConfiguration)
+            default: return []
+            }
+        }
+        
+        print("DEBUG prefetching \(imageRequests.count) images for \(numPosts) posts")
+        
+        prefetchingConfiguration.prefetcher.startPrefetching(with: imageRequests)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentStream.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/User Content Feed Loader/PersonContentStream.swift
@@ -33,6 +33,7 @@ public class PersonContentStream<Item: PersonContentProviding> {
     var needsMoreItems: Bool { !doneLoading && cursor >= items.count }
     
     func reset() {
+        items = .init()
         cursor = 0
         doneLoading = false
         thresholds = .init()


### PR DESCRIPTION
This PR completely reworks the `FeedLoader` architecture to use native Swift `actor`s for concurrency management. This is achieved by the addition of two new components: the `LoadingActor` and the `Fetcher`.

## `LoadingActor`

The `LoadingActor` is an `actor` that is responsible for loading. Because `actor`s are extremely inflexible, this is designed to be as minimal and generic as possible; it can be thought of as the "kernel" of the loading system. The `LoadingActor` defines two operations:
- `load`: loads the next page of items
- `reset`: resets the loading state

The behavior of these operations is subject to the following behavior requirements:
1. It should be possible to call both `reset` and `load` while an existing `load` call is awaiting the server response
2. If `reset` is called while the actor is loading, the existing load should be immediately cancelled
3. If `load` is called while the actor is loading, the new load call should be ignored

These requirements ensure that the frontend is responsive (e.g., refreshing the feed does not require waiting for an existing load to complete just to be thrown out) and duplicate loads (e.g., as caused by scrolling fast and hitting both the normal and the fallback threshold) are ignored.

To support this behavior, the `LoadingActor` stores a `loadingTask`. This is an independent `Task` that performs the actual server call; if no server call is in progress, `loadingTask` is nil. `load` spawns this task then awaits its result; the `await` operation frees up the actor to handle new `reset` or `load` calls. This architecture satisfies the above requirements:
1. New `load` or `reset` operations can be handled as soon as the `loadingTask` is spawned.
2. If a `reset` call comes in while `loadingTask` is non-nil, it simply calls `Task.cancel()` on the `loadingTask`. That `loadingTask` will return a `cancelled` status.
3. If a `load` call comes in while `loadingTask` is non-nil, `load` returns the `ignored` status.

## `Fetcher`

Swift does not allow inheritance with `actor`s. This renders `LoadingActor` highly inflexible; each fetch use cases requires tracking a unique set of fetch parameters, which is inelegant to handle within the `LoadingActor` itself. `LoadingActor` is therefore instantiated with a `Fetcher`: a class which provides the `fetchPage` and `fetchCursor` methods and handles the unique fetch parameters for each loader. The `Fetcher` is stored within the `FeedLoader` and passed as a reference into the `LoadingActor`, allowing the `FeedLoader` to modify fetching behavior (e.g., change the query string for a search fetch).

## Responsibility Changes

The `FeedLoader` looks largely the same as before, but with much of its operation now delegated to the `Fetcher` and the `LoadingActor`. Most notably, the `FeedLoader`'s `loadingState` no longer has concurrency management responsibilities. The responsibilities of each component are as follows:

`FeedLoader` | `Fetcher` | `LoadingActor`
---|---|---
Filtering, custom post-fetch processing (e.g., image prefetching), and handling frontend requests | Tracking fetch parameters and defining fetching behavior | Concurrency management