### PR TITLE
Fix Person1 block bug

### DIFF
--- a/Sources/MlemMiddleware/API Client/Caching/Caches/PersonCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/PersonCaches.swift
@@ -35,7 +35,7 @@ class Person1Cache: ApiTypeBackedCache<Person1, ApiPerson> {
             deleted: apiType.deleted,
             isBot: apiType.botAccount,
             instanceBan: instanceBan,
-            blocked: false // TODO: can we know this?
+            blocked: nil
         )
     }
     


### PR DESCRIPTION
Fixed a bug in which `Person1.blocked` was assumed to be `false` too early. Setting it to `nil` causes the `Person1` initializer to check if the `Person1` is in the `BlockList`, which was the intended behavior.