### PR TITLE
Remove & Purge Community

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Community.swift
@@ -103,4 +103,23 @@ public extension ApiClient {
         let person = caches.community2.getModel(api: self, from: response.communityView, semaphore: semaphore)
         return person
     }
+    
+    @discardableResult
+    func removeCommunity(
+        id: Int,
+        remove: Bool,
+        reason: String?,
+        semaphore: UInt? = nil
+    ) async throws -> Community2 {
+        let request = RemoveCommunityRequest(communityId: id, removed: remove, reason: reason, expires: nil)
+        let response = try await perform(request)
+        return await caches.community2.getModel(api: self, from: response.communityView, semaphore: semaphore)
+    }
+    
+    func purgeCommunity(id: Int, reason: String?) async throws {
+        let request = PurgeCommunityRequest(communityId: id, reason: reason)
+        let response = try await perform(request)
+        guard response.success else { throw ApiClientError.unsuccessful }
+        caches.community1.retrieveModel(cacheId: id)?.purged = true
+    }
 }

--- a/Sources/MlemMiddleware/API Client/Caching/Caches/PersonCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/PersonCaches.swift
@@ -56,7 +56,8 @@ class Person2Cache: CoreCache<Person2> {
             api: api,
             person1: api.caches.person1.getModel(api: api, from: apiType.person),
             postCount: apiType.counts.postCount,
-            commentCount: apiType.counts.commentCount
+            commentCount: apiType.counts.commentCount,
+            isAdmin: apiType.admin
         )
         itemCache.put(newItem)
         return newItem
@@ -93,7 +94,6 @@ class Person4Cache: ApiTypeBackedCache<Person4, ApiMyUserInfo> {
         return .init(
             api: api,
             person3: api.caches.person3.getModel(api: api, from: apiType),
-            isAdmin: user.admin,
             voteDisplayMode: apiType.localUserView.localUserVoteDisplayMode,
             email: user.email,
             showNsfw: user.showNsfw,

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Community+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Community+CacheExtensions.swift
@@ -14,7 +14,7 @@ extension Community1: CacheIdentifiable {
         setIfChanged(\.updated, community.updated)
         setIfChanged(\.displayName, community.title)
         setIfChanged(\.description, community.description)
-        setIfChanged(\.removed, community.removed)
+        removedManager.updateWithReceivedValue(community.removed, semaphore: semaphore)
         setIfChanged(\.deleted, community.deleted)
         setIfChanged(\.nsfw, community.nsfw)
         setIfChanged(\.avatar, community.icon)

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Person+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Person+CacheExtensions.swift
@@ -38,6 +38,7 @@ extension Person2: CacheIdentifiable {
     public var cacheId: Int { id }
     
     func update(with apiType: any Person2ApiBacker, semaphore: UInt? = nil) {
+        setIfChanged(\.isAdmin, apiType.admin)
         setIfChanged(\.postCount, apiType.counts.postCount)
         setIfChanged(\.commentCount, apiType.counts.commentCount)
         person1.update(with: apiType.person, semaphore: semaphore)
@@ -63,7 +64,9 @@ extension Person4: CacheIdentifiable {
         
         let user = apiMyUserInfo.localUserView.localUser
         
-        setIfChanged(\.isAdmin, user.admin)
+        if let admin = user.admin {
+            setIfChanged(\.person2.isAdmin, admin)
+        }
         setIfChanged(\.voteDisplayMode, apiMyUserInfo.localUserView.localUserVoteDisplayMode)
         setIfChanged(\.email, user.email)
         setIfChanged(\.showNsfw, user.showNsfw)

--- a/Sources/MlemMiddleware/Content Models/Comment/Comment1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Comment/Comment1Providing.swift
@@ -13,6 +13,7 @@ public protocol Comment1Providing:
         ContentIdentifiable,
         Interactable1Providing,
         DeletableProviding,
+        RemovableProviding,
         PurgableProviding,
         SelectableContentProviding,
         FeedLoadable where FilterType == CommentFilterType {
@@ -26,8 +27,6 @@ public protocol Comment1Providing:
     var postId: Int { get }
     var parentCommentIds: [Int] { get }
     var distinguished: Bool { get }
-    var removed: Bool { get }
-    var removedManager: StateManager<Bool> { get }
     var languageId: Int { get }
 }
 
@@ -136,7 +135,6 @@ public extension Comment1Providing {
     
     func purge(reason: String?) async throws {
         try await api.purgeComment(id: id, reason: reason)
-        self.comment1.purged = true
     }
     
     @discardableResult

--- a/Sources/MlemMiddleware/Content Models/Community/Community1.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/Community1.swift
@@ -23,7 +23,6 @@ public final class Community1: Community1Providing {
     public var updated: Date? = .distantPast
     public var displayName: String = ""
     public var description: String?
-    public var removed: Bool = false
     public var deleted: Bool = false
     public var nsfw: Bool = false
     public var avatar: URL?
@@ -31,9 +30,14 @@ public final class Community1: Community1Providing {
     public var hidden: Bool = false
     public var onlyModeratorsCanPost: Bool = false
     
+    public var purged: Bool = false
+    
     // This isn't included in ApiCommunity - it's included in ApiCommunityView, but defined here to maintain similarity with Person models. Person models don't have the `blocked` property defined in any of the Api types, annoyingly. Instead, certain parent models such as ApiPostView contain the value.
     internal var blockedManager: StateManager<Bool>
     public var blocked: Bool { blockedManager.wrappedValue }
+    
+    public var removedManager: StateManager<Bool>
+    public var removed: Bool { removedManager.wrappedValue }
   
     internal init(
         api: ApiClient,
@@ -61,7 +65,7 @@ public final class Community1: Community1Providing {
         self.updated = updated
         self.displayName = displayName
         self.description = description
-        self.removed = removed
+        self.removedManager = .init(wrappedValue: removed)
         self.deleted = deleted
         self.nsfw = nsfw
         self.avatar = avatar

--- a/Sources/MlemMiddleware/Content Models/Community/CommunityStubProviding.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/CommunityStubProviding.swift
@@ -15,6 +15,7 @@ public protocol CommunityStubProviding: CommunityOrPersonStub {
     var displayName_: String? { get }
     var description_: String? { get }
     var removed_: Bool? { get }
+    var removedManager_: StateManager<Bool>? { get }
     var deleted_: Bool? { get }
     var nsfw_: Bool? { get }
     var avatar_: URL? { get }
@@ -22,6 +23,7 @@ public protocol CommunityStubProviding: CommunityOrPersonStub {
     var hidden_: Bool? { get }
     var onlyModeratorsCanPost_: Bool? { get }
     var blocked_: Bool? { get }
+    var purged_: Bool? { get }
     
     // From Community2Providing.
     var subscribed_: Bool? { get }
@@ -52,6 +54,7 @@ public extension CommunityStubProviding {
     var displayName_: String? { nil }
     var description_: String? { nil }
     var removed_: Bool? { nil }
+    var removedManager_: StateManager<Bool>? { nil }
     var deleted_: Bool? { nil }
     var nsfw_: Bool? { nil }
     var avatar_: URL? { nil }
@@ -59,6 +62,7 @@ public extension CommunityStubProviding {
     var hidden_: Bool? { nil }
     var onlyModeratorsCanPost_: Bool? { nil }
     var blocked_: Bool? { nil }
+    var purged_: Bool? { nil }
     
     // From Community2Providing.
     var subscribed_: Bool? { nil }

--- a/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Interactable/Interactable2Providing.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 // Content that can be upvoted, downvoted, saved etc
-public protocol Interactable2Providing: Interactable1Providing, PurgableProviding {
+public protocol Interactable2Providing: Interactable1Providing, RemovableProviding, PurgableProviding {
     var creator: any Person { get }
     var community: any Community { get }
     var creatorIsModerator: Bool? { get }
@@ -17,17 +17,12 @@ public protocol Interactable2Providing: Interactable1Providing, PurgableProvidin
     var commentCount: Int { get }
     var votes: VotesModel { get }
     var saved: Bool { get }
-    var removedManager: StateManager<Bool> { get }
-    var removed: Bool { get }
     
     @discardableResult
     func updateVote(_ newVote: ScoringOperation) -> Task<StateUpdateResult, Never>
     
     @discardableResult
     func updateSaved(_ newValue: Bool) -> Task<StateUpdateResult, Never>
-    
-    @discardableResult
-    func updateRemoved(_ newValue: Bool, reason: String?) -> Task<StateUpdateResult, Never>
     
     func reply(content: String, languageId: Int?) async throws -> Comment2
 }
@@ -46,11 +41,6 @@ public extension Interactable2Providing {
     @discardableResult
     func toggleSaved() -> Task<StateUpdateResult, Never> {
         updateSaved(!saved)
-    }
-    
-    @discardableResult
-    func toggleRemoved(reason: String?) -> Task<StateUpdateResult, Never> {
-        updateRemoved(!removed, reason: reason)
     }
 }
 

--- a/Sources/MlemMiddleware/Content Models/Person/Person2.swift
+++ b/Sources/MlemMiddleware/Content Models/Person/Person2.swift
@@ -15,18 +15,22 @@ public final class Person2: Person2Providing {
     
     public let person1: Person1
     
-    public var postCount: Int = 0
-    public var commentCount: Int = 0
+    public var postCount: Int
+    public var commentCount: Int
+    
+    public var isAdmin: Bool
     
     internal init(
         api: ApiClient,
         person1: Person1,
-        postCount: Int = 0,
-        commentCount: Int = 0
+        postCount: Int,
+        commentCount: Int,
+        isAdmin: Bool
     ) {
         self.api = api
         self.person1 = person1
         self.postCount = postCount
         self.commentCount = commentCount
+        self.isAdmin = isAdmin
     }
 }

--- a/Sources/MlemMiddleware/Content Models/Person/Person2Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Person/Person2Providing.swift
@@ -12,6 +12,7 @@ public protocol Person2Providing: Person1Providing {
     
     var postCount: Int { get }
     var commentCount: Int { get }
+    var isAdmin: Bool { get }
 }
 
 public extension Person2Providing {
@@ -19,7 +20,10 @@ public extension Person2Providing {
     
     var postCount: Int { person2.postCount }
     var commentCount: Int { person2.commentCount }
-    
+    var isAdmin: Bool { person2.isAdmin }
+
     var postCount_: Int? { person2.postCount }
     var commentCount_: Int? { person2.commentCount }
+    var isAdmin_: Bool? { person2.isAdmin }
+
 }

--- a/Sources/MlemMiddleware/Content Models/Person/Person4.swift
+++ b/Sources/MlemMiddleware/Content Models/Person/Person4.swift
@@ -16,7 +16,6 @@ public final class Person4: Person4Providing {
 
     public let person3: Person3
     
-    public internal(set) var isAdmin: Bool?
     public internal(set) var voteDisplayMode: ApiLocalUserVoteDisplayMode?
     public internal(set) var email: String?
     public internal(set) var showNsfw: Bool
@@ -45,7 +44,6 @@ public final class Person4: Person4Providing {
     internal init(
         api: ApiClient,
         person3: Person3,
-        isAdmin: Bool?,
         voteDisplayMode: ApiLocalUserVoteDisplayMode?,
         email: String?,
         showNsfw: Bool,
@@ -73,7 +71,6 @@ public final class Person4: Person4Providing {
     ) {
         self.api = api
         self.person3 = person3
-        self.isAdmin = isAdmin
         self.voteDisplayMode = voteDisplayMode
         self.email = email
         self.showNsfw = showNsfw

--- a/Sources/MlemMiddleware/Content Models/Person/Person4Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Person/Person4Providing.swift
@@ -10,7 +10,6 @@ import Foundation
 public protocol Person4Providing: Person3Providing {
     var person4: Person4 { get }
     
-    var isAdmin: Bool? { get }
     var voteDisplayMode: ApiLocalUserVoteDisplayMode? { get }
     var email: String? { get }
     var showNsfw: Bool { get }
@@ -40,7 +39,6 @@ public protocol Person4Providing: Person3Providing {
 public extension Person4Providing {
     var person3: Person3 { person4.person3 }
     
-    var isAdmin: Bool? { person4.isAdmin }
     var voteDisplayMode: ApiLocalUserVoteDisplayMode? { person4.voteDisplayMode }
     var email: String? { person4.email }
     var showNsfw: Bool { person4.showNsfw }
@@ -66,7 +64,6 @@ public extension Person4Providing {
     var enableAnimatedImages: Bool? { person4.enableAnimatedImages }
     var collapseBotComments: Bool? { person4.collapseBotComments }
     
-    var isAdmin_: Bool? { person4.isAdmin }
     var voteDisplayMode_: ApiLocalUserVoteDisplayMode? { person4.voteDisplayMode }
     var email_: String? { person4.email }
     var showNsfw_: Bool? { person4.showNsfw }

--- a/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
@@ -13,6 +13,7 @@ public protocol Post1Providing:
         Interactable1Providing,
         SelectableContentProviding,
         DeletableProviding,
+        RemovableProviding,
         PurgableProviding,
         FeedLoadable where FilterType == PostFilterType {
     var post1: Post1 { get }
@@ -33,8 +34,6 @@ public protocol Post1Providing:
     var lockedManager: StateManager<Bool> { get }
     var nsfw: Bool { get }
     var created: Date { get }
-    var removed: Bool { get }
-    var removedManager: StateManager<Bool> { get }
     var thumbnailUrl: URL? { get }
     var updated: Date? { get }
     var languageId: Int { get }

--- a/Sources/MlemMiddleware/Content Models/RemovableProviding.swift
+++ b/Sources/MlemMiddleware/Content Models/RemovableProviding.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-15.
+//
+
+import Foundation
+
+public protocol RemovableProviding: ContentIdentifiable {
+    var removedManager: StateManager<Bool> { get }
+    var removed: Bool { get }
+    
+    @discardableResult
+    func updateRemoved(_ newValue: Bool, reason: String?) -> Task<StateUpdateResult, Never>
+}
+
+public extension RemovableProviding {
+    @discardableResult
+    func toggleRemoved(reason: String?) -> Task<StateUpdateResult, Never> {
+        updateRemoved(!removed, reason: reason)
+    }
+}

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APILocalUserView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APILocalUserView+Extensions.swift
@@ -7,4 +7,12 @@
 
 import Foundation
 
-extension ApiLocalUserView: Person2ApiBacker {}
+extension ApiLocalUserView: Person2ApiBacker {
+    public var admin: Bool {
+        if let admin = self.localUser.admin ?? self.person.admin {
+            return admin
+        }
+        assertionFailure()
+        return false
+    }
+}

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
@@ -7,4 +7,12 @@
 
 import Foundation
 
-extension ApiPersonView: Person2ApiBacker {}
+extension ApiPersonView: Person2ApiBacker {
+    public var admin: Bool {
+        if let admin = self.isAdmin ?? self.person.admin {
+            return admin
+        }
+        assertionFailure()
+        return false
+    }
+}

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APIPersonView+Extensions.swift
@@ -9,10 +9,10 @@ import Foundation
 
 extension ApiPersonView: Person2ApiBacker {
     public var admin: Bool {
-        if let admin = self.isAdmin ?? self.person.admin {
-            return admin
+        guard let admin = self.isAdmin ?? self.person.admin else {
+            assertionFailure("Could not determine admin status")
+            return false
         }
-        assertionFailure()
-        return false
+        return admin
     }
 }

--- a/Sources/MlemMiddleware/Custom API Models/Person2ApiBacker.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Person2ApiBacker.swift
@@ -11,6 +11,7 @@ import Foundation
 public protocol Person2ApiBacker: ActorIdentifiable, CacheIdentifiable, Identifiable {
     var person: ApiPerson { get }
     var counts: ApiPersonAggregates { get }
+    var admin: Bool { get }
 }
 
 public extension Person2ApiBacker {


### PR DESCRIPTION
Added remove and purge methods for communities, and moved the `isAdmin` property from `Person4` to `Person2`.