### PR TITLE
Make all sent messages appear read

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Comment.swift
@@ -133,8 +133,13 @@ public extension ApiClient {
     @discardableResult
     func reportComment(id: Int, reason: String) async throws -> Report {
         let request = CreateCommentReportRequest(commentId: id, reason: reason)
-        let response = try await perform(request)
-        return await caches.report.getModel(api: self, from: response.commentReportView)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModel(
+            api: self,
+            from: try response.commentReportView,
+            myPersonId: myPersonId
+        )
     }
     
     func purgeComment(id: Int, reason: String?) async throws {

--- a/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Inbox.swift
@@ -37,8 +37,13 @@ public extension ApiClient {
         unreadOnly: Bool = false
     ) async throws -> [Message2] {
         let request = GetPrivateMessagesRequest(unreadOnly: unreadOnly, page: page, limit: limit, creatorId: creatorId)
-        let response = try await perform(request)
-        return await caches.message2.getModels(api: self, from: response.privateMessages)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.message2.getModels(
+            api: self,
+            from: try response.privateMessages,
+            myPersonId: myPersonId
+        )
     }
     
     func markAllAsRead() async throws {
@@ -82,8 +87,14 @@ public extension ApiClient {
         semaphore: UInt? = nil
     ) async throws -> Message2 {
         let request = MarkPrivateMessageAsReadRequest(privateMessageId: id, read: read)
-        let response = try await perform(request)
-        return await caches.message2.getModel(api: self, from: response.privateMessageView, semaphore: semaphore)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.message2.getModel(
+            api: self,
+            from: try response.privateMessageView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
     }
     
     @discardableResult
@@ -105,28 +116,49 @@ public extension ApiClient {
     
     func createMessage(personId: Int, content: String) async throws -> Message2 {
         let request = CreatePrivateMessageRequest(content: content, recipientId: personId)
-        let response = try await perform(request)
-        return await caches.message2.getModel(api: self, from: response.privateMessageView)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.message2.getModel(
+            api: self,
+            from: try response.privateMessageView,
+            myPersonId: myPersonId
+        )
     }
     
     @discardableResult
     func editMessage(id: Int, content: String) async throws -> Message2 {
         let request = EditPrivateMessageRequest(privateMessageId: id, content: content)
-        let response = try await perform(request)
-        return await caches.message2.getModel(api: self, from: response.privateMessageView)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.message2.getModel(
+            api: self,
+            from: try response.privateMessageView,
+            myPersonId: myPersonId
+        )
     }
     
     @discardableResult
     func reportMessage(id: Int, reason: String) async throws -> Report {
         let request = CreatePrivateMessageReportRequest(privateMessageId: id, reason: reason)
-        let response = try await perform(request)
-        return await caches.report.getModel(api: self, from: response.privateMessageReportView)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModel(
+            api: self,
+            from: try response.privateMessageReportView,
+            myPersonId: myPersonId
+        )
     }
     
     @discardableResult
     func deleteMessage(id: Int, delete: Bool, semaphore: UInt? = nil) async throws -> Message2 {
         let request = DeletePrivateMessageRequest(privateMessageId: id, deleted: delete)
-        let response = try await perform(request)
-        return await caches.message2.getModel(api: self, from: response.privateMessageView, semaphore: semaphore)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.message2.getModel(
+            api: self,
+            from: try response.privateMessageView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
     }
 }

--- a/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Post.swift
@@ -318,8 +318,13 @@ public extension ApiClient {
     @discardableResult
     func reportPost(id: Int, reason: String) async throws -> Report {
         let request = CreatePostReportRequest(postId: id, reason: reason)
-        let response = try await perform(request)
-        return await caches.report.getModel(api: self, from: response.postReportView)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModel(
+            api: self,
+            from: try response.postReportView,
+            myPersonId: myPersonId
+        )
     }
     
     func purgePost(id: Int, reason: String?) async throws {

--- a/Sources/MlemMiddleware/API Client/ApiClient+Report.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Report.swift
@@ -22,8 +22,13 @@ public extension ApiClient {
             communityId: communityId,
             postId: postId
         )
-        let response = try await perform(request)
-        return await caches.report.getModels(api: self, from: response.postReports)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModels(
+            api: self,
+            from: try response.postReports,
+            myPersonId: myPersonId
+        )
     }
     
     func getCommentReports(
@@ -40,8 +45,13 @@ public extension ApiClient {
             communityId: communityId,
             commentId: commentId
         )
-        let response = try await perform(request)
-        return await caches.report.getModels(api: self, from: response.commentReports)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModels(
+            api: self,
+            from: try response.commentReports,
+            myPersonId: myPersonId
+        )
     }
     
     func getMessageReports(
@@ -54,8 +64,13 @@ public extension ApiClient {
             limit: limit,
             unresolvedOnly: unresolvedOnly
         )
-        let response = try await perform(request)
-        return await caches.report.getModels(api: self, from: response.privateMessageReports)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModels(
+            api: self,
+            from: try response.privateMessageReports,
+            myPersonId: myPersonId
+        )
     }
     
     @discardableResult
@@ -65,8 +80,14 @@ public extension ApiClient {
         semaphore: UInt? = nil
     ) async throws -> Report {
         let request = ResolvePostReportRequest(reportId: id, resolved: resolved)
-        let response = try await perform(request)
-        return await caches.report.getModel(api: self, from: response.postReportView, semaphore: semaphore)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModel(
+            api: self,
+            from: try response.postReportView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
     }
     
     @discardableResult
@@ -76,8 +97,14 @@ public extension ApiClient {
         semaphore: UInt? = nil
     ) async throws -> Report {
         let request = ResolveCommentReportRequest(reportId: id, resolved: resolved)
-        let response = try await perform(request)
-        return await caches.report.getModel(api: self, from: response.commentReportView, semaphore: semaphore)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModel(
+            api: self,
+            from: try response.commentReportView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
     }
     
     @discardableResult
@@ -87,7 +114,13 @@ public extension ApiClient {
         semaphore: UInt? = nil
     ) async throws -> Report {
         let request = ResolvePrivateMessageReportRequest(reportId: id, resolved: resolved)
-        let response = try await perform(request)
-        return await caches.report.getModel(api: self, from: response.privateMessageReportView, semaphore: semaphore)
+        async let response = try await perform(request)
+        guard let myPersonId = try await myPersonId else { throw ApiClientError.notLoggedIn }
+        return await caches.report.getModel(
+            api: self,
+            from: try response.privateMessageReportView,
+            myPersonId: myPersonId,
+            semaphore: semaphore
+        )
     }
 }

--- a/Sources/MlemMiddleware/API Client/Caching/Caches/MessageCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/MessageCaches.swift
@@ -19,7 +19,7 @@ class Message1Cache: ApiTypeBackedCache<Message1, ApiPrivateMessage> {
             deleted: apiType.deleted,
             created: apiType.published,
             updated: apiType.updated,
-            read: apiType.read
+            read: (api.myPerson?.id == apiType.creatorId) ? true : apiType.read
         )
     }
     

--- a/Sources/MlemMiddleware/API Client/Caching/Caches/ReportCaches.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Caches/ReportCaches.swift
@@ -10,7 +10,12 @@ import Foundation
 // Report can be created from any ReportApiBacker, so we can't use ApiTypeBackedCache
 class ReportCache: CoreCache<Report> {
     @MainActor
-    func getModel(api: ApiClient, from apiType: any ReportApiBacker, semaphore: UInt? = nil) -> Report {
+    func getModel(
+        api: ApiClient,
+        from apiType: any ReportApiBacker,
+        myPersonId: Int,
+        semaphore: UInt? = nil
+    ) -> Report {
         if let item = retrieveModel(cacheId: apiType.cacheId) {
             item.update(with: apiType, semaphore: semaphore)
             return item
@@ -21,7 +26,7 @@ class ReportCache: CoreCache<Report> {
             id: apiType.id,
             creator: api.caches.person1.getModel(api: api, from: apiType.creator, semaphore: semaphore),
             resolver: api.caches.person1.getOptionalModel(api: api, from: apiType.resolver, semaphore: semaphore),
-            target: apiType.createTarget(api: api),
+            target: apiType.createTarget(api: api, myPersonId: myPersonId),
             resolved: apiType.resolved,
             reason: apiType.reason,
             created: apiType.published,
@@ -32,7 +37,12 @@ class ReportCache: CoreCache<Report> {
     }
     
     @MainActor
-    func getModels(api: ApiClient, from apiTypes: [any ReportApiBacker], semaphore: UInt? = nil) -> [Report] {
-        apiTypes.map { getModel(api: api, from: $0, semaphore: semaphore) }
+    func getModels(
+        api: ApiClient,
+        from apiTypes: [any ReportApiBacker],
+        myPersonId: Int,
+        semaphore: UInt? = nil
+    ) -> [Report] {
+        apiTypes.map { getModel(api: api, from: $0, myPersonId: myPersonId, semaphore: semaphore) }
     }
 }

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Message+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Message+CacheExtensions.swift
@@ -16,10 +16,9 @@ extension Message1: CacheIdentifiable {
         setIfChanged(\.updated, message.updated)
         
         deletedManager.updateWithReceivedValue(message.deleted, semaphore: semaphore)
-        readManager.updateWithReceivedValue(
-            (api.myPerson?.id == message.creatorId) ? true : message.read,
-            semaphore: semaphore
-        )
+        if !isOwnMessage {
+            readManager.updateWithReceivedValue(message.read, semaphore: semaphore)
+        }
     }
 }
 

--- a/Sources/MlemMiddleware/API Client/Caching/Conformance/Message+CacheExtensions.swift
+++ b/Sources/MlemMiddleware/API Client/Caching/Conformance/Message+CacheExtensions.swift
@@ -16,7 +16,10 @@ extension Message1: CacheIdentifiable {
         setIfChanged(\.updated, message.updated)
         
         deletedManager.updateWithReceivedValue(message.deleted, semaphore: semaphore)
-        readManager.updateWithReceivedValue(message.read, semaphore: semaphore)
+        readManager.updateWithReceivedValue(
+            (api.myPerson?.id == message.creatorId) ? true : message.read,
+            semaphore: semaphore
+        )
     }
 }
 

--- a/Sources/MlemMiddleware/API Client/Helpers/SharedTaskManager.swift
+++ b/Sources/MlemMiddleware/API Client/Helpers/SharedTaskManager.swift
@@ -1,0 +1,32 @@
+//
+//  SharedTaskManager.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2024-12-27.
+//  
+
+import Foundation
+
+internal class SharedTaskManager<Value> {
+    let fetchTask: () async throws -> Value
+    
+    private var ongoingTask: Task<Value, Error>?
+    internal private(set) var fetchedValue: Value?
+    
+    init(fetchTask: @escaping () async throws -> Value) {
+        self.fetchTask = fetchTask
+    }
+    
+    func getValue() async throws -> Value {
+        if let fetchedValue {
+            return fetchedValue
+        } else {
+            if let ongoingTask {
+                let result = await ongoingTask.result
+                return try result.get()
+            } else {
+                return try await fetchTask()
+            }
+        }
+    }
+}

--- a/Sources/MlemMiddleware/Content Models/Message/Message1.swift
+++ b/Sources/MlemMiddleware/Content Models/Message/Message1.swift
@@ -21,6 +21,7 @@ public final class Message1: Message1Providing {
     public var content: String
     public let created: Date
     public var updated: Date?
+    public let isOwnMessage: Bool
     
     internal let readManager: StateManager<Bool>
     public var read: Bool { readManager.wrappedValue }
@@ -33,6 +34,7 @@ public final class Message1: Message1Providing {
          id: Int,
          creatorId: Int,
          recipientId: Int,
+         isOwnMessage: Bool,
          content: String,
          deleted: Bool,
          created: Date,
@@ -44,11 +46,12 @@ public final class Message1: Message1Providing {
         self.id = id
         self.creatorId = creatorId
         self.recipientId = recipientId
+        self.isOwnMessage = isOwnMessage
         self.content = content
         self.deletedManager = .init(wrappedValue: deleted)
         self.created = created
         self.updated = updated
-        self.readManager = .init(wrappedValue: read)
+        self.readManager = .init(wrappedValue: isOwnMessage ? true : read)
         self.readManager.onSet = { newValue, type, semaphore in
             if type == .begin || type == .rollback {
                 api.unreadCount?.updateUnverifiedItem(itemType: .message, isRead: newValue)

--- a/Sources/MlemMiddleware/Content Models/Message/Message1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Message/Message1Providing.swift
@@ -61,6 +61,7 @@ public extension Message1Providing {
     var created: Date { message1.created }
     var updated: Date? { message1.updated }
     var read: Bool { message1.read }
+    var isOwnMessage: Bool { message1.isOwnMessage }
     
     var id_: Int? { message1.id }
     var creatorId_: Int? { message1.creatorId }
@@ -70,6 +71,7 @@ public extension Message1Providing {
     var created_: Date? { message1.created }
     var updated_: Date? { message1.updated }
     var read_: Bool? { message1.read }
+    var isOwnMessage_: Bool? { message1.isOwnMessage }
     
     var creator_: Person1? { nil }
     var recipient_: Person1? { nil }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentReportView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/ApiCommentReportView+Extensions.swift
@@ -41,7 +41,7 @@ extension ApiCommentReportView: ReportApiBacker {
     }
     
     @MainActor
-    func createTarget(api: ApiClient) -> ReportTarget {
+    func createTarget(api: ApiClient, myPersonId: Int) -> ReportTarget {
         if let commentView = toCommentView() {
             return .comment(api.caches.comment2.getModel(api: api, from: commentView))
         }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPostReportView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPostReportView+Extensions.swift
@@ -44,7 +44,7 @@ extension ApiPostReportView: ReportApiBacker {
     }
     
     @MainActor
-    func createTarget(api: ApiClient) -> ReportTarget {
+    func createTarget(api: ApiClient, myPersonId: Int) -> ReportTarget {
         if let postView = toPostView() {
             return .post(api.caches.post2.getModel(api: api, from: postView))
         }

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPrivateMessageReportView+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/ApiPrivateMessageReportView+Extensions.swift
@@ -30,8 +30,14 @@ extension ApiPrivateMessageReportView: ReportApiBacker {
     }
     
     @MainActor
-    func createTarget(api: ApiClient) -> ReportTarget {
-        .message(api.caches.message2.getModel(api: api, from: toPrivateMessageView()))
+    func createTarget(api: ApiClient, myPersonId: Int) -> ReportTarget {
+        .message(
+            api.caches.message2.getModel(
+                api: api,
+                from: toPrivateMessageView(),
+                myPersonId: myPersonId
+            )
+        )
     }
 }
 

--- a/Sources/MlemMiddleware/Custom API Models/ReportApiBacker.swift
+++ b/Sources/MlemMiddleware/Custom API Models/ReportApiBacker.swift
@@ -17,5 +17,5 @@ protocol ReportApiBacker: CacheIdentifiable, Identifiable where ID == Int {
     var updated: Date? { get }
     
     @MainActor
-    func createTarget(api: ApiClient) -> ReportTarget
+    func createTarget(api: ApiClient, myPersonId: Int) -> ReportTarget
 }


### PR DESCRIPTION
All sent messages are now considered read. In order to find out whether a message is our own, we need to fetch our own person ID and compare it to the message sender ID. I've implemented a system similar to the ApiClient `version` property for this - you can now `await api.myPersonId` to get the person ID.