### PR TITLE
Fix instance actorId issue

### DIFF
--- a/Sources/MlemMiddleware/Content Models/ActorIdentifier.swift
+++ b/Sources/MlemMiddleware/Content Models/ActorIdentifier.swift
@@ -39,12 +39,15 @@ public struct ActorIdentifier: Hashable {
     ///
     public init?(url: URL) {
         guard let host = url.host() else { return nil }
-        self.url = url
-        self.host = host
+        self.init(url: url, host: host)
     }
     
     private init(url: URL, host: String) {
-        self.url = url
+        if url.pathComponents.isEmpty {
+            self.url = url.appendingPathComponent("/")
+        } else {
+            self.url = url
+        }
         self.host = host
     }
     


### PR DESCRIPTION
Fixed an issue where instance actorIds sometimes had a trailing slash and sometimes didn't. This could cause comparisons to fail when they should have succeeded. For example, the instance block list wouldn't show any instances before this fix.

This doesn't require an Mlem PR