### PR TITLE
Load full size images

### DIFF
--- a/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/Post1Providing.swift
@@ -153,10 +153,6 @@ public extension Post1Providing {
             
             // if image, return image link, otherwise return thumbnail
             if linkUrl.isMedia {
-                if let thumbnailUrl {
-                    // lemmy-ui always shows the `thumbnailUrl` if available even in expanded view
-                    return .media(thumbnailUrl)
-                }
                 return .media(linkUrl)
             }
             return .link(.init(content: linkUrl, thumbnail: thumbnailUrl, label: embed?.title ?? title))


### PR DESCRIPTION
Closes mlemgroup/mlem#1438; does not require a Mlem PR.

Previously we always used `thumbnailUrl` if available for media, which predictably enough caused images to load in at lower resolutions.