### PR TITLE
ApiClient hash value changes

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -31,7 +31,17 @@ public extension ApiClient {
             password: password,
             totp2faToken: totpToken
         )
-        return try await perform(request)
+        return try await perform(request, allowedWhenTokenless: true)
+    }
+    
+    func login(password: String, totpToken: String?) async throws {
+        guard let username else { throw ApiClientError.notLoggedIn }
+        let response = try await self.getAccountToken(username: username, password: password, totpToken: totpToken)
+        if let jwt = response.jwt {
+            self.updateToken(jwt)
+        } else {
+            throw ApiClientError.unsuccessful
+        }
     }
     
     func signUp(

--- a/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -25,7 +25,7 @@ public extension ApiClient {
     
     // Returns a raw API type :(
     // Probably OK because it's part of onboarding, which is cursed and bootstrappy
-    func logIn(username: String, password: String, totpToken: String?) async throws -> ApiLoginResponse {
+    func getAccountToken(username: String, password: String, totpToken: String?) async throws -> ApiLoginResponse {
         let request = LoginRequest(
             usernameOrEmail: username,
             password: password,

--- a/Sources/MlemMiddleware/API Client/ApiClient+General.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+General.swift
@@ -31,7 +31,7 @@ public extension ApiClient {
             password: password,
             totp2faToken: totpToken
         )
-        return try await perform(request, allowedWhenTokenless: true)
+        return try await perform(request, requiresToken: false)
     }
     
     func login(password: String, totpToken: String?) async throws {

--- a/Sources/MlemMiddleware/API Client/ApiClient+Mock.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Mock.swift
@@ -15,8 +15,8 @@ public extension ApiClient {
 public class MockApiClient: ApiClient {
     public init() {
         super.init(
-            baseUrl: URL(string: "https://example.com/")!,
-            token: nil, permissions: .none
+            url: URL(string: "https://example.com/")!,
+            username: nil, permissions: .none
         )
     }
 }

--- a/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient+Person.swift
@@ -203,6 +203,12 @@ public extension ApiClient {
     func getMyPerson() async throws -> (person: Person4?, instance: Instance3, blocks: BlockList?) {
         let request = GetSiteRequest()
         let response = try await perform(request)
+        
+        guard response.myUser?.localUserView.person.name == self.username else {
+            assertionFailure()
+            throw ApiClientError.mismatchingToken
+        }
+        
         let instance = await caches.instance3.getModel(api: self, from: response)
         
         var blocks: BlockList? = self.blocks

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -130,10 +130,10 @@ public class ApiClient {
     @discardableResult
     func perform<Request: ApiRequest>(
         _ request: Request,
-        allowedWhenTokenless: Bool = false // This should be `false` for the vast majority of requests, even GET requests
+        requiresToken: Bool = true // This should be `true` for the vast majority of requests, even GET requests
     ) async throws -> Request.Response {
         
-        guard allowedWhenTokenless || self.username == nil || self.token != nil else {
+        guard !requiresToken || self.username == nil || self.token != nil else {
             throw ApiClientError.noToken
         }
         

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -18,9 +18,11 @@ public class ApiClient {
     let decoder: JSONDecoder = .defaultDecoder
     let urlSession: URLSession = .init(configuration: .default)
     
-    // url and token MAY NOT be modified! Downstream code expects that a given ApiClient will *always* submit requests from the same user to the same instance.
+    // url and username MAY NOT be modified! Downstream code expects that a given ApiClient will *always* submit requests from the same user to the same instance.
     public let baseUrl: URL
     let endpointUrl: URL
+    public let username: String?
+    
     public private(set) var token: String?
     
     public private(set) var contextDataManager: SharedTaskManager<Context> = .init()
@@ -81,22 +83,19 @@ public class ApiClient {
     static var apiClientCache: ApiClientCache = .init()
     
     /// Creates or retrieves an API client for the given connection parameters
-    public static func getApiClient(
-        for url: URL,
-        with token: String?
-    ) -> ApiClient {
-        apiClientCache.createOrRetrieveApiClient(for: url, with: token)
+    public static func getApiClient(url: URL, username: String?) -> ApiClient {
+        apiClientCache.createOrRetrieveApiClient(url: url, username: username)
     }
     
     /// This should never be used outside of ApiClientCache (and MockApiClient), as the caching system depends on one ApiClient existing for any given session.
     internal init(
-        baseUrl: URL,
-        token: String? = nil,
+        url: URL,
+        username: String? = nil,
         permissions: RequestPermissions = .all
     ) {
-        self.baseUrl = baseUrl
-        self.endpointUrl = baseUrl.appendingPathComponent("api/v3")
-        self.token = token
+        self.baseUrl = url
+        self.username = username
+        self.endpointUrl = url.appendingPathComponent("api/v3")
         self.permissions = permissions
         contextDataManager.fetchTask = {
             let (person, instance, _) = try await self.getMyPerson()
@@ -109,28 +108,35 @@ public class ApiClient {
         ApiClient.apiClientCache.clean()
     }
     
-    /// Return a new `ApiClient` without a token.
-    public func loggedOut() -> ApiClient {
-        .getApiClient(for: self.baseUrl, with: nil)
+    /// Return a new guest `ApiClient`.
+    public func asGuest() -> ApiClient {
+        .getApiClient(url: self.baseUrl, username: nil)
     }
     
-    /// Return a new `ApiClient` with the given token.
-    public func loggedIn(token: String) -> ApiClient {
-        .getApiClient(for: self.baseUrl, with: token)
+    /// Return a new `ApiClient` targeting the given user.
+    public func asUser(name: String) -> ApiClient {
+        .getApiClient(url: self.baseUrl, username: name)
     }
     
     /// This should **only** be used when we get a new token for **the same** account!
     public func updateToken(_ newToken: String) {
-        guard token != nil else {
+        guard username != nil else {
             assertionFailure()
             return
         }
-        Self.apiClientCache.changeToken(for: baseUrl, oldToken: token, newToken: newToken)
         self.token = newToken
     }
     
     @discardableResult
-    func perform<Request: ApiRequest>(_ request: Request) async throws -> Request.Response {
+    func perform<Request: ApiRequest>(
+        _ request: Request,
+        allowedWhenTokenless: Bool = false // This should be `false` for the vast majority of requests, even GET requests
+    ) async throws -> Request.Response {
+        
+        guard allowedWhenTokenless || self.username == nil || self.token != nil else {
+            throw ApiClientError.noToken
+        }
+        
         let urlRequest = try urlRequest(from: request)
         // this line intentionally left commented for convenient future debugging
         // urlRequest.debug()
@@ -239,7 +245,7 @@ public class ApiClient {
 
 extension ApiClient: CacheIdentifiable {
     public var cacheId: Int {
-        ApiClient.apiClientCache.getCacheId(for: baseUrl, with: token)
+        ApiClient.apiClientCache.getCacheId(url: baseUrl, username: username)
     }
 }
 
@@ -250,7 +256,7 @@ extension ApiClient: ActorIdentifiable {
 extension ApiClient: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.baseUrl)
-        hasher.combine(self.token)
+        hasher.combine(self.username)
     }
     
     public static func == (lhs: ApiClient, rhs: ApiClient) -> Bool {
@@ -283,32 +289,20 @@ extension ApiClient {
 extension ApiClient {
     /// Cache for ApiClient--exception case because there's no ApiType and it may need to perform ApiClient bootstrapping
     class ApiClientCache: CoreCache<ApiClient> {
-        func getCacheId(for baseUrl: URL, with token: String?) -> Int {
+        func getCacheId(url: URL, username: String?) -> Int {
             var hasher: Hasher = .init()
-            hasher.combine(baseUrl)
-            hasher.combine(token)
+            hasher.combine(url)
+            hasher.combine(username)
             return hasher.finalize()
         }
-        func createOrRetrieveApiClient(for baseUrl: URL, with token: String?) -> ApiClient {
-            if let client = retrieveModel(cacheId: getCacheId(for: baseUrl, with: token)) {
+        func createOrRetrieveApiClient(url: URL, username: String?) -> ApiClient {
+            if let client = retrieveModel(cacheId: getCacheId(url: url, username: username)) {
                 return client
             }
             
-            let ret: ApiClient = .init(baseUrl: baseUrl, token: token)
+            let ret: ApiClient = .init(url: url, username: username)
             itemCache.put(ret)
             return ret
-        }
-        
-        // Should ONLY be used when we get a new token for THE SAME account
-        func changeToken(for baseUrl: URL, oldToken: String?, newToken: String?) {
-            let oldCacheId = getCacheId(for: baseUrl, with: oldToken)
-            let newCacheId = getCacheId(for: baseUrl, with: newToken)
-            guard let cachedClient = itemCache.get(oldCacheId) else {
-                assertionFailure("Failed to find old ApiClient in cache!")
-                return
-            }
-            itemCache.put(cachedClient, overrideCacheId: newCacheId)
-            itemCache.remove(oldCacheId)
         }
     }
 }

--- a/Sources/MlemMiddleware/API Client/ApiClientError.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClientError.swift
@@ -29,6 +29,8 @@ public enum ApiClientError: Error {
     case imageTooLarge
     case mismatchingUrl
     case mismatchingPersonId
+    case mismatchingToken
+    case noToken
 }
 
 extension ApiClientError: CustomStringConvertible {
@@ -75,6 +77,10 @@ extension ApiClientError: CustomStringConvertible {
             return "URL of the decoding ApiClient doesn't match the URL of the ApiClient that encoded the data"
         case .mismatchingPersonId:
             return "Person ID of the decoding ApiClient doesn't match the Person ID of the ApiClient that encoded the data"
+        case .mismatchingToken:
+            return "A valid token was assigned to an ApiClient for the wrong account."
+        case .noToken:
+            return "A call was made to an ApiClient that doesn't have a token yet."
         }
     }
 }

--- a/Sources/MlemMiddleware/Content Models/Comment/CommentStub.swift
+++ b/Sources/MlemMiddleware/Content Models/Comment/CommentStub.swift
@@ -18,7 +18,7 @@ public struct CommentStub: CommentStubProviding, Hashable {
     }
     
     public func asLocal() -> Self {
-        .init(api: .getApiClient(for: url.removingPathComponents(), with: nil), url: url)
+        .init(api: .getApiClient(url: url.removingPathComponents(), username: nil), url: url)
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/Sources/MlemMiddleware/Content Models/Community/CommunityStub.swift
+++ b/Sources/MlemMiddleware/Content Models/Community/CommunityStub.swift
@@ -18,7 +18,7 @@ public struct CommunityStub: CommunityStubProviding, Hashable {
     }
     
     public func asLocal() -> Self {
-        .init(api: .getApiClient(for: url.removingPathComponents(), with: nil), url: url)
+        .init(api: .getApiClient(url: url.removingPathComponents(), username: nil), url: url)
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/Instance1Providing.swift
@@ -71,7 +71,7 @@ public extension Instance1Providing {
     var name: String { host } // TODO: Remove this?
     
     var guestApi: ApiClient {
-        .getApiClient(for: local ? api.baseUrl : actorId.hostUrl, with: nil)
+        .getApiClient(url: local ? api.baseUrl : actorId.hostUrl, username: nil)
     }
     
     @discardableResult

--- a/Sources/MlemMiddleware/Content Models/Instance/InstanceStub.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/InstanceStub.swift
@@ -20,7 +20,7 @@ public struct InstanceStub: InstanceStubProviding, Hashable {
     }
     
     public func asLocal() -> Self {
-        .init(api: .getApiClient(for: actorId.hostUrl, with: nil), actorId: actorId)
+        .init(api: .getApiClient(url: actorId.hostUrl, username: nil), actorId: actorId)
     }
     
     public func hash(into hasher: inout Hasher) {
@@ -43,7 +43,7 @@ public extension InstanceStub {
     /// Due to API limitations (see [here](https://github.com/mlemgroup/mlem/pull/1029#issuecomment-2067746011)),
     /// it takes 4 API calls to perform this upgrade.
     func upgrade() async throws -> Instance1 {
-        let externalApi: ApiClient = .getApiClient(for: actorId.url, with: nil)
+        let externalApi: ApiClient = .getApiClient(url: actorId.url, username: nil)
         
         let response = try await externalApi.getPosts(
             feed: .local,

--- a/Sources/MlemMiddleware/Content Models/Instance/InstanceStubProviding.swift
+++ b/Sources/MlemMiddleware/Content Models/Instance/InstanceStubProviding.swift
@@ -125,7 +125,7 @@ public enum InstanceUpgradeError: Error {
 public extension InstanceStubProviding {
     /// Upgrade to an ``Instance3``, using the instance's local ``ApiClient``. This will not work for locally running instances.
     func upgradeLocal() async throws -> Instance3 {
-        let externalApi: ApiClient = apiIsLocal ? api : .getApiClient(for: actorId.url, with: nil)
+        let externalApi: ApiClient = apiIsLocal ? api : .getApiClient(url: actorId.url, username: nil)
         return try await externalApi.getMyInstance()
     }
 }

--- a/Sources/MlemMiddleware/Content Models/Person/PersonStub.swift
+++ b/Sources/MlemMiddleware/Content Models/Person/PersonStub.swift
@@ -19,7 +19,7 @@ public struct PersonStub: PersonStubProviding, Hashable {
     }
     
     public func asLocal() -> Self {
-        .init(api: .getApiClient(for: url, with: nil), url: url)
+        .init(api: .getApiClient(url: url, username: nil), url: url)
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/Sources/MlemMiddleware/Content Models/Post/PostStub.swift
+++ b/Sources/MlemMiddleware/Content Models/Post/PostStub.swift
@@ -18,7 +18,7 @@ public struct PostStub: PostStubProviding, Hashable {
     }
     
     public func asLocal() -> Self {
-        .init(api: .getApiClient(for: url.removingPathComponents(), with: nil), url: url)
+        .init(api: .getApiClient(url: url.removingPathComponents(), username: nil), url: url)
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/Sources/MlemMiddleware/Protocols/UpgradableProtocol.swift
+++ b/Sources/MlemMiddleware/Protocols/UpgradableProtocol.swift
@@ -27,7 +27,7 @@ public extension Upgradable {
     func upgradeFromLocal() async throws {
         if let wrappedValue = wrappedValue as? any ActorIdentifiable {
             try await upgrade(
-                api: .getApiClient(for: wrappedValue.actorId.hostUrl, with: nil),
+                api: .getApiClient(url: wrappedValue.actorId.hostUrl, username: nil),
                 upgradeOperation: nil
             )
         } else {


### PR DESCRIPTION
Made some changes to the ApiClient architecture.

Previously, the `cacheId` and `hashValue` of `ApiClient` were created by hashing the `baseUrl` and the `token`. This wasn't ideal for a number of reasons:
- It was possible to create two different `ApiClient` instances for the same account by giving them different tokens.
- The `hashValue` of `ApiClient` would change if you change the token.
- It will be impossible to include `token` in `hashValue` if we ever switch to Swift 6 strict concurrency (issue [here](https://github.com/mlemgroup/mlem/issues/931)) and isolate `ApiClient` to an actor, because `token` is mutable.

To remedy this, I've added a new `username` property to `ApiClient`. If you want to create an authenticated `ApiClient`, you are required to provide the username of the account. `username` is now used instead of `token` in the `cacheId` and `hashValue`.

The downside of doing this is that we *must* have the `username` of an account available if we want to send requests using it. I can't think of a scenario in which we'd have a valid token but not the username though, so I think the benefits outweigh the risks.

--------

I've also made it possible to create a tokenless non-guest `ApiClient`. If you try to perform a request on such a client, it will throw `ApiClient.noToken`. This happens for all requests, including requests that don't require authentication.

This change makes the process of creating an authenticated `ApiClient` without knowing the token slightly easier. Previously, we had to do this:

```swift
let guestClient: ApiClient = .getApiClient(for: url, with: nil)
let loginResponse = try await guestClient.login(username: username, password: password)
let apiClient: ApiClient = .getApiClient(for: url, with: loginResponse.jwt)
```

After this change, you can now do this:

```swift
let apiClient: ApiClient = .getApiClient(url: url, username: username)
try await apiClient.login(password: password)
```

Mlem needs the guest `ApiClient` beforehand anyways to display the instance avatar in the login sheet, so I haven't changed the way in which Mlem authenticated clients for now. I may do some rewriting another time. It's still nice to have this syntax available though.