### PR TITLE
Fix feed loaders sometimes not loading after applying filters

### DIFF
--- a/Sources/MlemMiddleware/FeedLoaders/Generics/ChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/ChildFeedLoader.swift
@@ -34,7 +34,7 @@ public class ChildFeedLoader<Item: FeedLoadable>: StandardFeedLoader<Item> {
         assert(sortType == self.sortType, "Conflicting types for sortType! This will lead to unexpected sorting behavior.")
         
         guard let stream, stream.parent != nil else {
-            print("[\(Item.self) ChildFeedLoader] could not find stream or parent")
+            print("[\(Self.self)] could not find stream or parent")
             return nil
         }
         
@@ -42,11 +42,11 @@ public class ChildFeedLoader<Item: FeedLoadable>: StandardFeedLoader<Item> {
             return items[safeIndex: stream.cursor]?.sortVal(sortType: sortType)
         } else {
             if loadingState == .done {
-                print("[\(Item.self) ChildFeedLoader] done loading")
+                print("[\(Self.self)] done loading")
                 return nil
             }
             
-            print("[\(Item.self) ChildFeedLoader] out of items (\(items.count)), loading more")
+            print("[\(Self.self)] out of items (\(items.count)), loading more")
             try await loadMoreItems()
             
             if stream.cursor >= items.count {
@@ -55,14 +55,14 @@ public class ChildFeedLoader<Item: FeedLoadable>: StandardFeedLoader<Item> {
                 return nil
             }
             
-            print("[\(Item.self) ChildFeedLoader] fetched more items (\(items.count))")
+            print("[\(Self.self)] fetched more items (\(items.count))")
             return items[stream.cursor].sortVal(sortType: sortType)
         }
     }
     
     public func consumeNextItem() -> Item? {
         guard let stream, stream.parent != nil else {
-            assertionFailure("[\(Item.self) ChildFeedLoader] could not find stream or parent")
+            assertionFailure("[\(Item.self)] could not find stream or parent")
             return nil
         }
         

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/Fetcher.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/Fetcher.swift
@@ -59,7 +59,7 @@ public class Fetcher<Item: FeedLoadable> {
     func fetch() async throws -> LoadingResponse<Item> {
         do {
             if let cursor, page > 0 {
-                print("[\(Item.self) Fetcher] loading cursor \(cursor)")
+                print("[\(Self.self)] loading cursor \(cursor)")
                 let response = try await fetchCursor(cursor)
                 
                 // if same cursor returned, loading is finished
@@ -71,12 +71,12 @@ public class Fetcher<Item: FeedLoadable> {
                 return .success(response.items)
             } else {
                 page += 1
-                print("[\(Item.self) Fetcher] loading page \(page)")
+                print("[\(Self.self)] loading page \(page)")
                 let response = try await fetchPage(page)
                 
                 // if nothing returned, loading is finished
                 if response.items.count < pageSize {
-                    print("[\(Item.self) Fetcher] received undersized page (\(response.items.count)/\(pageSize))")
+                    print("[\(Self.self)] received undersized page (\(response.items.count)/\(pageSize))")
                     return .done(response.items)
                 }
                 self.cursor = response.nextCursor

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/Fetcher.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/Fetcher.swift
@@ -59,7 +59,7 @@ public class Fetcher<Item: FeedLoadable> {
     func fetch() async throws -> LoadingResponse<Item> {
         do {
             if let cursor, page > 0 {
-                print("[\(Self.self)] loading cursor \(cursor)")
+                print("[\(Item.self) Fetcher] loading cursor \(cursor)")
                 let response = try await fetchCursor(cursor)
                 
                 // if same cursor returned, loading is finished
@@ -71,12 +71,12 @@ public class Fetcher<Item: FeedLoadable> {
                 return .success(response.items)
             } else {
                 page += 1
-                print("[\(Self.self)] loading page \(page)")
+                print("[\(Item.self) Fetcher] loading page \(page)")
                 let response = try await fetchPage(page)
                 
                 // if nothing returned, loading is finished
                 if response.items.count < pageSize {
-                    print("[\(Self.self)] received undersized page (\(response.items.count)/\(pageSize))")
+                    print("[\(Item.self) Fetcher] received undersized page (\(response.items.count)/\(pageSize))")
                     return .done(response.items)
                 }
                 self.cursor = response.nextCursor

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/LoadingActor.swift
@@ -36,16 +36,16 @@ actor LoadingActor<Item: FeedLoadable> {
     /// - Returns: on success, .success with FetchResponse containing loaded items; if another load is underway, .ignored; if the load is cancelled, .cancelled
     func load(_ callback: @escaping (LoadingResponse<Item>) async -> Void) async throws {
         guard !done else {
-            print("[\(Item.self) LoadingActor] ignoring request, finished loading")
+            print("[\(Self.self)] ignoring request, finished loading")
             return
         }
         
         // if already loading something, ignore the request
         if let loadingTask {
-            print("[\(Item.self) LoadingActor] ignoring request, load underway")
+            print("[\(Self.self)] ignoring request, load underway")
             // return .ignored
             let _ = try await loadingTask.result.get()
-            print("[\(Item.self) LoadingActor] preexisting load finished, returning")
+            print("[\(Self.self)] preexisting load finished, returning")
             return
         }
         
@@ -63,7 +63,7 @@ actor LoadingActor<Item: FeedLoadable> {
         }
         
         let _ = try await loadingTask.result.get()
-        print("[\(Item.self) LoadingActor] finished loading")
+        print("[\(Self.self)] finished loading")
     }
     
     @discardableResult
@@ -97,14 +97,14 @@ actor LoadingActor<Item: FeedLoadable> {
             
             switch response {
             case let .success(items):
-                print("[\(Item.self) LoadingActor] received success (\(items.count))")
+                print("[\(Self.self)] received success (\(items.count))")
                 newItems.append(contentsOf: filter.filter(items))
             case let .done(items):
-                print("[\(Item.self) LoadingActor] received finished (\(items.count))")
+                print("[\(Self.self)] received finished (\(items.count))")
                 newItems.append(contentsOf: filter.filter(items))
                 return .done(newItems)
             case .cancelled, .ignored:
-                print("[\(Item.self) LoadingActor] load did not complete (\(response.description))")
+                print("[\(Self.self)] load did not complete (\(response.description))")
                 break fetchLoop
             }
         } while newItems.count < MiddlewareConstants.infiniteLoadThresholdOffset

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/MultiFetcher.swift
@@ -26,7 +26,7 @@ class MultiFetcher<Item: FeedLoadable>: Fetcher<Item> {
             if let nextItem = try await computeNextItem() {
                 newItems.append(nextItem)
             } else {
-                print("[\(Item.self) MultiFetcher] no next item found")
+                print("[\(Self.self)] no next item found")
                 return .done(newItems)
             }
         }
@@ -37,7 +37,7 @@ class MultiFetcher<Item: FeedLoadable>: Fetcher<Item> {
     override func reset() async {
         for source in sources {
             await source.clear(clearParent: false)
-            print("[\(Item.self) MultiFetcher] source cleared (\(source.loadingState))")
+            print("[\(Self.self)] source cleared (\(source.loadingState))")
         }
         
         await super.reset()

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -29,7 +29,7 @@ public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
     @MainActor
     func setLoading(_ newState: LoadingState) {
         loadingState = newState
-        print("[\(Item.self) FeedLoader] set loading state to \(newState)")
+        print("[\(Self.self)] set loading state to \(newState)")
     }
     
     /// Sets the items to a new array
@@ -94,7 +94,7 @@ public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
                 newItems = items
                 newState = .done
             case .ignored, .cancelled:
-                print("[\(Item.self) FeedLoader] load did not complete (\(response.description))")
+                print("[\(Self.self)] load did not complete (\(response.description))")
                 newState = .idle
             }
             
@@ -107,7 +107,7 @@ public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
             }
             
             await self.setLoading(newState)
-            print("[\(Item.self) FeedLoader] loadMoreItems complete")
+            print("[\(Self.self)] loadMoreItems complete")
         }
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -143,6 +143,9 @@ public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
             
             if items.isEmpty {
                 try await refresh(clearBeforeRefresh: false)
+            } else if thresholds.fallback == nil {
+                // if too few items are present after filtering to trigger threshold loading, initiate new load
+                try await loadMoreItems()
             }
         }
     }


### PR DESCRIPTION
Closes mlemgroup/mlem#1544; does not strictly require a Mlem PR, but https://github.com/mlemgroup/mlem/pull/1767 prevents "load more" from flickering in for a frame.

Most of the line count is logging changes. The only code changes are StandardFeedLoader 146-148; `loadMoreItems()` is now automatically called when a filter is activated and the filtered items list is too short for threshold loading. This prevents the loader from entering an inescapable `idle` state.