### PR TITLE
Tweak `ApiGetRequest` structure

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -207,7 +207,7 @@ public class ApiClient {
     ) throws -> URLRequest {
         let token = tokenOverride ?? self.token
         guard permissions != .none else { throw ApiClientError.insufficientPermissions }
-        let url = definition.endpoint(base: endpointUrl)
+        let url = try definition.endpoint(base: endpointUrl, version: fetchedVersion ?? .infinity)
         var urlRequest = URLRequest(url: url)
         for header in definition.headers {
             urlRequest.setValue(header.value, forHTTPHeaderField: header.key)

--- a/Sources/MlemMiddleware/API Client/ApiClient.swift
+++ b/Sources/MlemMiddleware/API Client/ApiClient.swift
@@ -207,7 +207,7 @@ public class ApiClient {
     ) throws -> URLRequest {
         let token = tokenOverride ?? self.token
         guard permissions != .none else { throw ApiClientError.insufficientPermissions }
-        let url = try definition.endpoint(base: endpointUrl, version: fetchedVersion ?? .infinity)
+        let url = try definition.endpoint(base: endpointUrl)
         var urlRequest = URLRequest(url: url)
         for header in definition.headers {
             urlRequest.setValue(header.value, forHTTPHeaderField: header.key)

--- a/Sources/MlemMiddleware/API Client/ApiRequest.swift
+++ b/Sources/MlemMiddleware/API Client/ApiRequest.swift
@@ -17,10 +17,10 @@ enum ApiRequestError: Error {
 protocol ApiRequest {
     associatedtype Response: Decodable
 
-    var path: String { get }
     var headers: [String: String] { get }
     
-    func endpoint(base: URL) -> URL
+    func path(on version: SiteVersion) -> String
+    func endpoint(base: URL, version: SiteVersion) throws -> URL
 }
 
 extension ApiRequest {
@@ -34,21 +34,27 @@ extension ApiRequest {
 // MARK: - ApiGetRequest
 
 protocol ApiGetRequest: ApiRequest {
-    var queryItems: [URLQueryItem] { get }
+    associatedtype Parameters: Encodable
+    var parameters: Parameters? { get }
 }
 
 extension ApiRequest {
-    func endpoint(base: URL) -> URL {
+    func endpoint(base: URL, version: SiteVersion) throws -> URL {
         base
-            .appending(path: path)
+            .appending(path: path(on: version))
     }
 }
 
 extension ApiGetRequest {
-    func endpoint(base: URL) -> URL {
-        base
-            .appending(path: path)
-            .appending(queryItems: queryItems.filter { $0.value != nil })
+    func endpoint(base: URL, version: SiteVersion) throws -> URL {
+        if let parameters {
+            base
+                .appending(path: path(on: version))
+                .appending(queryItems: try URLQueryItemEncoder.encode(parameters))
+        } else {
+            base
+                .appending(path: path(on: version))
+        }
     }
 }
 

--- a/Sources/MlemMiddleware/API Client/ApiRequest.swift
+++ b/Sources/MlemMiddleware/API Client/ApiRequest.swift
@@ -17,10 +17,10 @@ enum ApiRequestError: Error {
 protocol ApiRequest {
     associatedtype Response: Decodable
 
+    var path: String { get }
     var headers: [String: String] { get }
     
-    func path(on version: SiteVersion) -> String
-    func endpoint(base: URL, version: SiteVersion) throws -> URL
+    func endpoint(base: URL) throws -> URL
 }
 
 extension ApiRequest {
@@ -39,21 +39,21 @@ protocol ApiGetRequest: ApiRequest {
 }
 
 extension ApiRequest {
-    func endpoint(base: URL, version: SiteVersion) throws -> URL {
+    func endpoint(base: URL) throws -> URL {
         base
-            .appending(path: path(on: version))
+            .appending(path: path)
     }
 }
 
 extension ApiGetRequest {
-    func endpoint(base: URL, version: SiteVersion) throws -> URL {
+    func endpoint(base: URL) throws -> URL {
         if let parameters {
             base
-                .appending(path: path(on: version))
+                .appending(path: path)
                 .appending(queryItems: try URLQueryItemEncoder.encode(parameters))
         } else {
             base
-                .appending(path: path(on: version))
+                .appending(path: path)
         }
     }
 }

--- a/Sources/MlemMiddleware/API Client/Helpers/URLQueryItemEncoder.swift
+++ b/Sources/MlemMiddleware/API Client/Helpers/URLQueryItemEncoder.swift
@@ -1,0 +1,149 @@
+//
+//  URLQueryItemEncoder.swift
+//  MlemMiddleware
+//
+//  Created by Sjmarf on 2025-02-20.
+//
+
+import Foundation
+
+internal struct URLQueryItemEncoder {
+    static func encode<T: Encodable>(_ value: T) throws -> [URLQueryItem] {
+        let encoder = InternalURLQueryItemEncoder()
+        try value.encode(to: encoder)
+        return encoder.queryParams
+    }
+}
+
+internal enum URLQueryItemEncoderError: Error {
+    case nestedContainersUnsupported
+    case singleValueContainerUnsupported
+    case unkeyedContainerUnsupported
+}
+
+private class InternalURLQueryItemEncoder: Encoder {
+    var queryParams: [URLQueryItem] = .init()
+
+    // This is just for conformance to Encoder. This never gets modified because we
+    // disallow nested containers
+    let codingPath: [CodingKey] = []
+    
+    // Just for conformance; unused
+    let userInfo: [CodingUserInfoKey: Any] = [:]
+
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        // This value throws an error as soon as you try to encode with it
+        SingleValueContainer(encoder: self)
+    }
+
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        // This value throws an error as soon as you try to encode with it
+        UnkeyedContainer(encoder: self)
+    }
+
+    func container<Key: CodingKey>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
+        KeyedEncodingContainer(KeyedContainer<Key>(encoder: self))
+    }
+}
+
+private class KeyedContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
+    var encoder: InternalURLQueryItemEncoder
+
+    init(encoder: InternalURLQueryItemEncoder) {
+        self.encoder = encoder
+    }
+
+    var codingPath: [CodingKey] = []
+
+    func encodeNil(forKey key: K) throws {}
+
+    func encode<T: Encodable>(_ value: T, forKey key: K) throws {
+        if let valueString = self.convertValueToString(value) {
+            let key = key.stringValue.camelToSnakeCase()
+            encoder.queryParams.append(.init(name: key, value: valueString))
+        } else {
+            throw URLQueryItemEncoderError.nestedContainersUnsupported
+        }
+    }
+    
+    func convertValueToString<T: Encodable>(_ value: T) -> String? {
+        if let value = value as? String {
+            value
+        } else if let value = value as? Int {
+            String(value)
+        } else if let value = value as? Double {
+            String(value)
+        } else if let value = value as? Bool {
+            value ? "true" : "false"
+        } else if let value = value as? any RawRepresentable<String> {
+            value.rawValue
+        } else if let value = value as? any RawRepresentable<Int> {
+            String(value.rawValue)
+        } else {
+            nil
+        }
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) -> KeyedEncodingContainer<NestedKey> where NestedKey: CodingKey {
+        assertionFailure("We should throw an error *before* this gets called")
+        return KeyedEncodingContainer(KeyedContainer<NestedKey>(encoder: encoder))
+    }
+
+    func nestedUnkeyedContainer(forKey key: K) -> UnkeyedEncodingContainer {
+        assertionFailure("We should throw an error *before* this gets called")
+        return UnkeyedContainer(encoder: encoder)
+    }
+
+    func superEncoder() -> Encoder { encoder }
+    func superEncoder(forKey key: K) -> Encoder { encoder }
+}
+
+// This simply throws an error as soon as you try to encode with it.
+private class SingleValueContainer: SingleValueEncodingContainer {
+    let encoder: InternalURLQueryItemEncoder
+    let codingPath: [CodingKey] = []
+
+    init(encoder: InternalURLQueryItemEncoder) {
+        self.encoder = encoder
+    }
+
+    func encodeNil() throws {}
+
+    func encode<T: Encodable>(_ value: T) throws {
+        throw URLQueryItemEncoderError.singleValueContainerUnsupported
+    }
+}
+
+// This simply throws an error as soon as you try to encode with it.
+private class UnkeyedContainer: UnkeyedEncodingContainer {
+    let encoder: InternalURLQueryItemEncoder
+    let codingPath: [any CodingKey] = []
+    let count: Int = 0
+    
+    init(encoder: InternalURLQueryItemEncoder) {
+        self.encoder = encoder
+    }
+    
+    func encodeNil() throws {}
+    
+    func encode<T: Encodable>(_ value: T) throws { throw URLQueryItemEncoderError.unkeyedContainerUnsupported }
+    
+    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        assertionFailure("We should throw an error *before* this gets called")
+        return KeyedEncodingContainer(KeyedContainer(encoder: encoder))
+    }
+    
+    func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+        assertionFailure("We should throw an error *before* this gets called")
+        return UnkeyedContainer(encoder: encoder)
+    }
+    
+    func superEncoder() -> any Encoder { encoder }
+}
+
+private extension String {
+    func camelToSnakeCase() -> String {
+        self.replacing(/([a-z])([A-Z])/) { "\($0.output.1)_\($0.output.2)"
+        }.lowercased()
+    }
+}

--- a/Sources/MlemMiddleware/Content Models/ActorIdentifier.swift
+++ b/Sources/MlemMiddleware/Content Models/ActorIdentifier.swift
@@ -28,7 +28,7 @@ import Foundation
 ///
 /// It should be noted that private messages cannot be resolved using ``ResolveObjectRequest``.
 ///
-public struct ActorIdentifier: Hashable {
+public struct ActorIdentifier: Hashable, Sendable {
     public let url: URL
     public let host: String
     

--- a/Sources/MlemMiddleware/Content Models/Internal/SiteVersion.swift
+++ b/Sources/MlemMiddleware/Content Models/Internal/SiteVersion.swift
@@ -52,6 +52,7 @@ public enum SiteVersion: Equatable, Hashable {
     public static let v19_6: Self = .init("0.19.6")
     public static let v19_7: Self = .init("0.19.7")
     public static let v19_8: Self = .init("0.19.8")
+    public static let v19_9: Self = .init("0.19.9")
 }
 
 public extension SiteVersion {

--- a/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunity+Extensions.swift
+++ b/Sources/MlemMiddleware/Custom API Models/Extensions/APICommunity+Extensions.swift
@@ -17,8 +17,8 @@ extension ApiCommunity: Comparable {
     }
     
     public static func < (lhs: ApiCommunity, rhs: ApiCommunity) -> Bool {
-        let lhsFullCommunity = lhs.name + (lhs.actorId.host ?? "")
-        let rhsFullCommunity = rhs.name + (rhs.actorId.host ?? "")
+        let lhsFullCommunity = lhs.name + lhs.actorId.host
+        let rhsFullCommunity = rhs.name + rhs.actorId.host
         return lhsFullCommunity < rhsFullCommunity
     }
 }


### PR DESCRIPTION
Changes the way that `ApiGetRequest` is structured. 

Here's what we did before:

```swift
public struct GetCommentRequest: ApiGetRequest {
    public typealias Response = ApiCommentResponse

    public let path = "comment"
    public let queryItems: [URLQueryItem]

    init(id: Int) {
        self.queryItems = [
            .init(name: "id", value: String(id))
        ]
    }
}
```

And here's what it looks like after this PR:

```swift
public struct GetCommentRequest: ApiGetRequest {
    public typealias Parameters = ApiGetComment
    public typealias Response = ApiCommentResponse
    
    public let path = "comment"
    public let parameters: Parameters?
    
    init(id: Int) {
        self.parameters = .init(id: id)
    }
}
```

This system brings the `GET` request structure closer in line with that of our `POST` requests, which use a `Body` value in a similar way to the `Parameters` value shown above. This structure makes it much easier to modify the parameters of an `ApiGetRequest` *after* initialising it, should we ever need to do that.

In order to encode the `parameters` into `[URLQueryItem]`, I've implemented a custom `URLQueryItemEncoder`.

Closes #117

See also [this lemmy-swift-codegen PR](https://github.com/mlemgroup/lemmy-swift-codegen/pull/12) and [this MlemApiTypes PR](https://github.com/mlemgroup/MlemApiTypes/pull/17). No Mlem PR required.