### PR TITLE
Improve keyword filtering logic

### DIFF
--- a/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -20,13 +20,9 @@ public extension String {
     
     /// Returns true if this string contains any whole word that is in the given set of strings
     func failsKeywordFilter(_ filteredKeywords: Set<String>) -> Bool {
-        // let punctuationRegex = "[^a-zA-Z]" // matches single non-letter characters
         let words = self
-            // .replacingOccurrences(of: punctuationRegex, with: " ", options: [.regularExpression])
-            // .split(separator: " ")
             .split(separator: /[^a-zA-Z]/) // split on any non-letter characters so "keyword's" is filtered as "keyword" "s"
             .map { $0.lowercased() }
-        print("DEBUG \(words)")
         return words.contains { filteredKeywords.contains($0) }
     }
 }

--- a/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -20,11 +20,13 @@ public extension String {
     
     /// Returns true if this string contains any whole word that is in the given set of strings
     func failsKeywordFilter(_ filteredKeywords: Set<String>) -> Bool {
-        let punctuationRegex = "[^a-zA-Z]" // matches single non-letter characters
+        // let punctuationRegex = "[^a-zA-Z]" // matches single non-letter characters
         let words = self
-            .replacingOccurrences(of: punctuationRegex, with: " ", options: [.regularExpression])
-            .split(separator: " ")
+            // .replacingOccurrences(of: punctuationRegex, with: " ", options: [.regularExpression])
+            // .split(separator: " ")
+            .split(separator: /[^a-zA-Z]/) // split on any non-letter characters so "keyword's" is filtered as "keyword" "s"
             .map { $0.lowercased() }
+        print("DEBUG \(words)")
         return words.contains { filteredKeywords.contains($0) }
     }
 }

--- a/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -19,8 +19,12 @@ public extension String {
     }
     
     /// Returns true if this string contains any whole word that is in the given set of strings
-    func containsWordsIn(_ strings: Set<String>) -> Bool {
-        let words = self.split(separator: " ").map { $0.lowercased() }
-        return words.contains { strings.contains($0) }
+    func failsKeywordFilter(_ filteredKeywords: Set<String>) -> Bool {
+        let punctuationRegex = "[^a-zA-Z]" // matches single non-letter characters
+        let words = self
+            .replacingOccurrences(of: punctuationRegex, with: " ", options: [.regularExpression])
+            .split(separator: " ")
+            .map { $0.lowercased() }
+        return words.contains { filteredKeywords.contains($0) }
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Filtering/Filters/Post/PostKeywordFilter.swift
@@ -35,7 +35,7 @@ class PostKeywordFilter: FilterProviding {
         // bypass filter for moderated/administrated posts
         if context.isAdmin || context.moderatedCommunityActorIds.contains(post.community.actorId) { return true }
         
-        return !post.title.lowercased().containsWordsIn(context.filteredKeywords)
+        return !post.title.failsKeywordFilter(context.filteredKeywords)
     }
     
     func updateFilterContext(to context: FilterContext) {


### PR DESCRIPTION
Any non-letter character is now replaced with whitespace before keyword filters are applied. This catches a bunch of punctuation-related cases:
`keyword's`
`keyword-otherword`
`... keyword.`
`... keyword, ...`

Also renames `containsWordsIn` to `failsKeywordFilter`, since the logic is now pretty tightly coupled to that purpose.