### PR TITLE
Improved Filtering 2

### DIFF
--- a/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -23,7 +23,6 @@ public extension String {
         let words = self
             .split(separator: /[^[:alnum:]]/) // split on any non-letter/number characters so "keyword's" is filtered as "keyword" "s"
             .map { $0.lowercased() }
-        print("DEBUG \(words)")
         return words.contains { filteredKeywords.contains($0) }
     }
 }

--- a/Sources/MlemMiddleware/Extensions/String+Extensions.swift
+++ b/Sources/MlemMiddleware/Extensions/String+Extensions.swift
@@ -21,8 +21,9 @@ public extension String {
     /// Returns true if this string contains any whole word that is in the given set of strings
     func failsKeywordFilter(_ filteredKeywords: Set<String>) -> Bool {
         let words = self
-            .split(separator: /[^a-zA-Z]/) // split on any non-letter characters so "keyword's" is filtered as "keyword" "s"
+            .split(separator: /[^[:alnum:]]/) // split on any non-letter/number characters so "keyword's" is filtered as "keyword" "s"
             .map { $0.lowercased() }
+        print("DEBUG \(words)")
         return words.contains { filteredKeywords.contains($0) }
     }
 }


### PR DESCRIPTION
Improves the keyword filtering regex to use `:alnum:` instead of `a-zA-Z` for the splitter; this should handle non-ASCII much more effectively.

Credit to [d42ohpaz](https://github.com/mlemgroup/MlemMiddleware/pull/129#discussion_r1976520427).

This does not require a Mlem PR.