### PR TITLE
Fix `not_a_mod_or_admin` errors

### DIFF
--- a/Sources/MlemMiddleware/API Client/ApiErrorResponse.swift
+++ b/Sources/MlemMiddleware/API Client/ApiErrorResponse.swift
@@ -44,4 +44,6 @@ public extension ApiErrorResponse {
     var registrationApplicationIsPending: Bool { error == "registration_application_is_pending" }
     var emailNotVerified: Bool { error == "email_not_verified" }
     var couldntFindObject: Bool { couldntFindObjectErrors.contains(error) }
+    var notModOrAdmin: Bool { error == "not_a_mod_or_admin" }
+    var notAdmin: Bool { error == "not_an_admin" }
 }

--- a/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -102,7 +102,11 @@ public final class UnreadCount {
             }
             if !(self.api.myPerson?.moderatedCommunities.isEmpty ?? false) || self.api.isAdmin {
                 taskGroup.addTask {
-                    try await self.api.getReportCount(communityId: nil).unreadCountDictionary
+                    do {
+                        return try await self.api.getReportCount(communityId: nil).unreadCountDictionary
+                    } catch let ApiClientError.response(response, _) where response.error == "not_a_mod_or_admin" {
+                        return [:]
+                    }
                 }
             }
             // Don't use `api.isAdmin` here; it falls back to `false` and we need to fallback to `true`

--- a/Sources/MlemMiddleware/Content Models/UnreadCount.swift
+++ b/Sources/MlemMiddleware/Content Models/UnreadCount.swift
@@ -104,7 +104,7 @@ public final class UnreadCount {
                 taskGroup.addTask {
                     do {
                         return try await self.api.getReportCount(communityId: nil).unreadCountDictionary
-                    } catch let ApiClientError.response(response, _) where response.error == "not_a_mod_or_admin" {
+                    } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
                         return [:]
                     }
                 }
@@ -114,7 +114,7 @@ public final class UnreadCount {
                 taskGroup.addTask {
                     do {
                         return try await self.api.getRegistrationApplicationCount().unreadCountDictionary
-                    } catch let ApiClientError.response(response, _) where response.error == "not_an_admin" {
+                    } catch let ApiClientError.response(response, _) where response.notAdmin {
                         return [:]
                     }
                 }

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -161,6 +161,8 @@ public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
     }
     
     public func changeApi(to newApi: ApiClient, context: FilterContext) async {
-        await fetcher.changeApi(to: newApi, context: context)
+        if fetcher.api != newApi {
+            await fetcher.changeApi(to: newApi, context: context)
+        }
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Generics/StandardFeedLoader.swift
@@ -161,8 +161,6 @@ public class StandardFeedLoader<Item: FeedLoadable>: FeedLoading {
     }
     
     public func changeApi(to newApi: ApiClient, context: FilterContext) async {
-        if fetcher.api != newApi {
-            await fetcher.changeApi(to: newApi, context: context)
-        }
+        await fetcher.changeApi(to: newApi, context: context)
     }
 }

--- a/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ApplicationChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ApplicationChildFeedLoader.swift
@@ -17,7 +17,7 @@ public class ApplicationChildFeedLoader: ModMailChildFeedLoader {
                     prevCursor: nil,
                     nextCursor: nil
                 )
-            } catch let ApiClientError.response(response, _) where response.error == "not_an_admin" {
+            } catch let ApiClientError.response(response, _) where response.notAdmin {
                 return .init(items: .init(), prevCursor: nil, nextCursor: nil)
             }
         }

--- a/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ApplicationChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/ApplicationChildFeedLoader.swift
@@ -10,12 +10,16 @@ public class ApplicationChildFeedLoader: ModMailChildFeedLoader {
         override func fetchPage(_ page: Int) async throws -> FetchResponse {
             guard api.isAdmin else { return .init(items: [], prevCursor: nil, nextCursor: nil) }
             
-            let response = try await api.getRegistrationApplications(page: page, limit: pageSize, unreadOnly: unreadOnly)
-            return .init(
-                items: response.map { .application($0) },
-                prevCursor: nil,
-                nextCursor: nil
-            )
+            do {
+                let response = try await api.getRegistrationApplications(page: page, limit: pageSize, unreadOnly: unreadOnly)
+                return .init(
+                    items: response.map { .application($0) },
+                    prevCursor: nil,
+                    nextCursor: nil
+                )
+            } catch let ApiClientError.response(response, _) where response.error == "not_an_admin" {
+                return .init(items: .init(), prevCursor: nil, nextCursor: nil)
+            }
         }
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/CommentReportChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/CommentReportChildFeedLoader.swift
@@ -8,11 +8,16 @@
 public class CommentReportChildFeedLoader: ModMailChildFeedLoader {
     class Fetcher: ModMailFetcher {
         override func fetchPage(_ page: Int) async throws -> FetchResponse {
-            let response = try await api.getCommentReports(page: page, limit: pageSize, unresolvedOnly: unreadOnly)
-            return .init(items: response.map { .report($0) },
-                         prevCursor: nil,
-                         nextCursor: nil
-            )
+            do {
+                let response = try await api.getCommentReports(page: page, limit: pageSize, unresolvedOnly: unreadOnly)
+                return .init(
+                    items: response.map { .report($0) },
+                    prevCursor: nil,
+                    nextCursor: nil
+                )
+            } catch let ApiClientError.response(response, _) where response.error == "not_a_mod_or_admin" {
+                return .init(items: .init(), prevCursor: nil, nextCursor: nil)
+            }
         }
     }
 

--- a/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/CommentReportChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/CommentReportChildFeedLoader.swift
@@ -15,7 +15,7 @@ public class CommentReportChildFeedLoader: ModMailChildFeedLoader {
                     prevCursor: nil,
                     nextCursor: nil
                 )
-            } catch let ApiClientError.response(response, _) where response.error == "not_a_mod_or_admin" {
+            } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
                 return .init(items: .init(), prevCursor: nil, nextCursor: nil)
             }
         }

--- a/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/MessageReportChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/MessageReportChildFeedLoader.swift
@@ -10,12 +10,16 @@ public class MessageReportChildFeedLoader: ModMailChildFeedLoader {
         override func fetchPage(_ page: Int) async throws -> FetchResponse {
             guard api.isAdmin else { return .init(items: [], prevCursor: nil, nextCursor: nil) }
             
-            let response = try await api.getMessageReports(page: page, limit: pageSize, unresolvedOnly: unreadOnly)
-            return .init(
-                items: response.map { .report($0) },
-                prevCursor: nil,
-                nextCursor: nil
-            )
+            do {
+                let response = try await api.getMessageReports(page: page, limit: pageSize, unresolvedOnly: unreadOnly)
+                return .init(
+                    items: response.map { .report($0) },
+                    prevCursor: nil,
+                    nextCursor: nil
+                )
+            } catch let ApiClientError.response(response, _) where response.error == "not_an_admin" {
+                return .init(items: .init(), prevCursor: nil, nextCursor: nil)
+            }
         }
     }
 

--- a/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/MessageReportChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/MessageReportChildFeedLoader.swift
@@ -17,7 +17,7 @@ public class MessageReportChildFeedLoader: ModMailChildFeedLoader {
                     prevCursor: nil,
                     nextCursor: nil
                 )
-            } catch let ApiClientError.response(response, _) where response.error == "not_an_admin" {
+            } catch let ApiClientError.response(response, _) where response.notAdmin {
                 return .init(items: .init(), prevCursor: nil, nextCursor: nil)
             }
         }

--- a/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/PostReportChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/PostReportChildFeedLoader.swift
@@ -8,12 +8,16 @@
 public class PostReportChildFeedLoader: ModMailChildFeedLoader {
     class Fetcher: ModMailFetcher {
         override func fetchPage(_ page: Int) async throws -> FetchResponse {
-            let response = try await api.getPostReports(page: page, limit: pageSize)
-            return .init(
-                items: response.map { .report($0) },
-                prevCursor: nil,
-                nextCursor: nil
-            )
+            do {
+                let response = try await api.getPostReports(page: page, limit: pageSize)
+                return .init(
+                    items: response.map { .report($0) },
+                    prevCursor: nil,
+                    nextCursor: nil
+                )
+            } catch let ApiClientError.response(response, _) where response.error == "not_a_mod_or_admin" {
+                return .init(items: .init(), prevCursor: nil, nextCursor: nil)
+            }
         }
     }
     

--- a/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/PostReportChildFeedLoader.swift
+++ b/Sources/MlemMiddleware/FeedLoaders/Inbox/ModMailFeedLoader/PostReportChildFeedLoader.swift
@@ -15,7 +15,7 @@ public class PostReportChildFeedLoader: ModMailChildFeedLoader {
                     prevCursor: nil,
                     nextCursor: nil
                 )
-            } catch let ApiClientError.response(response, _) where response.error == "not_a_mod_or_admin" {
+            } catch let ApiClientError.response(response, _) where response.notModOrAdmin {
                 return .init(items: .init(), prevCursor: nil, nextCursor: nil)
             }
         }


### PR DESCRIPTION
Backend changes to address mlemgroup/mlem#1825. Does not require a Mlem PR, but [this Mlem PR](https://github.com/mlemgroup/mlem/pull/1826) is pointed at this branch so the changes can be easily tested.

Report feed loaders and the report count in `UnreadCount` now catch `not_an_admin` and `not_a_mod_or_admin` errors and return safe values.

Thanks to the joy of multithreading, there are some race conditions that cause these functions to be called from the frontend which would be extremely painful to resolve; the frontend doesn't ever display the empty responses unless something goes _seriously_ wrong, but the calls still get made and the errors still pop up.